### PR TITLE
Add Manual Workflow Dispatch for On-Demand Deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,16 @@ on:
       - 'feature/**'        # Feature branch previews
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment target'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
 
 permissions:
   contents: write
@@ -54,7 +64,9 @@ jobs:
     name: Deploy to Production (cjunker.dev)
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: |
+      (github.ref == 'refs/heads/master' && github.event_name == 'push') ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
 
     environment:
       name: production
@@ -87,7 +99,9 @@ jobs:
     name: Deploy to Staging (staging.cjunker.dev)
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref != 'refs/heads/master' && github.event_name == 'push'
+    if: |
+      (github.ref != 'refs/heads/master' && github.event_name == 'push') ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging')
 
     environment:
       name: staging


### PR DESCRIPTION
## Summary

Adds manual deployment capability via GitHub Actions workflow dispatch, allowing any branch to be deployed to staging or production on-demand from the GitHub UI.

## Changes

- Added `workflow_dispatch` trigger with environment selection dropdown
- Updated `deploy-production` job condition to support manual triggers
- Updated `deploy-staging` job condition to support manual triggers
- Default deployment target is staging (safest option)

## Use Cases

### Deploy PR to Staging Before Merge
1. Navigate to Actions → Deploy Production + Staging workflow
2. Click "Run workflow"
3. Select the branch (e.g., `feature/mobile-first-design`)
4. Choose "staging" environment
5. Click "Run workflow"
6. Review at https://staging.cjunker.dev

### Emergency Production Deploy
1. Same steps as above
2. Choose "production" environment
3. Deploy any branch directly to https://cjunker.dev

## Testing

- [x] Workflow syntax validated
- [ ] Test manual staging deployment from a feature branch
- [ ] Verify deployment shows up in Environments tab

## Benefits

- Preview PRs before merging (addresses feedback from deployment review)
- Test breaking changes in staging environment
- Emergency hotfix deployments without waiting for PR merge
- Better aligns with continuous deployment best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)