### PR TITLE
feat: add Babble Buddy and Exportee to featured projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,36 @@
             <div class="projects-grid">
                 <article class="brutal-card-v2 brutal-card-v2--halftone">
                     <div class="brutal-card-v2__header">
+                        <h3 class="brutal-card-v2__title">EXPORTEE</h3>
+                    </div>
+                    <div class="brutal-card-v2__content">
+                        <p class="project-card__tech">
+                            <small>Python/FastAPI • React • PostgreSQL • Docker</small>
+                        </p>
+                        <p>
+                            Self-hosted data export and transformation engine with read-only database connections,
+                            PII detection/masking, widget-based transformations, and compliance audit logging
+                            (HIPAA/FERPA/GDPR). Supports multiple export formats with optional encryption.
+                        </p>
+                        <div class="project-card__actions">
+                            <a href="https://exportee.cjunker.dev"
+                               class="brutal-card-v2__action"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                Live Demo
+                            </a>
+                            <a href="https://github.com/cjunks94/exportee"
+                               class="project-card__link"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                View on GitHub →
+                            </a>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="brutal-card-v2 brutal-card-v2--halftone">
+                    <div class="brutal-card-v2__header">
                         <h3 class="brutal-card-v2__title">BABBLE_BUDDY</h3>
                     </div>
                     <div class="brutal-card-v2__content">
@@ -275,30 +305,6 @@
                                target="_blank"
                                rel="noopener noreferrer">
                                 View on GitHub →
-                            </a>
-                        </div>
-                    </div>
-                </article>
-
-                <article class="brutal-card-v2 brutal-card-v2--halftone">
-                    <div class="brutal-card-v2__header">
-                        <h3 class="brutal-card-v2__title">EXPORTEE</h3>
-                    </div>
-                    <div class="brutal-card-v2__content">
-                        <p class="project-card__tech">
-                            <small>Python/FastAPI • React • PostgreSQL • Docker</small>
-                        </p>
-                        <p>
-                            Self-hosted data export and transformation engine with read-only database connections,
-                            PII detection/masking, widget-based transformations, and compliance audit logging
-                            (HIPAA/FERPA/GDPR). Supports multiple export formats with optional encryption.
-                        </p>
-                        <div class="project-card__actions">
-                            <a href="https://github.com/cjunks94/exportee"
-                               class="brutal-card-v2__action"
-                               target="_blank"
-                               rel="noopener noreferrer">
-                                View on GitHub
                             </a>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -252,6 +252,60 @@
             <div class="projects-grid">
                 <article class="brutal-card-v2 brutal-card-v2--halftone">
                     <div class="brutal-card-v2__header">
+                        <h3 class="brutal-card-v2__title">BABBLE_BUDDY</h3>
+                    </div>
+                    <div class="brutal-card-v2__content">
+                        <p class="project-card__tech">
+                            <small>Python/FastAPI • TypeScript • Ollama • PostgreSQL</small>
+                        </p>
+                        <p>
+                            Embeddable AI chatbot widget connecting to self-hosted Ollama backends. Features SSE streaming,
+                            token-based auth, rate limiting, theming system, and markdown rendering. Zero-framework vanilla
+                            JS widget for maximum portability.
+                        </p>
+                        <div class="project-card__actions">
+                            <a href="https://demo-production-d4be.up.railway.app"
+                               class="brutal-card-v2__action"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                Live Demo
+                            </a>
+                            <a href="https://github.com/cjunks94/babble-buddy"
+                               class="project-card__link"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                View on GitHub →
+                            </a>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="brutal-card-v2 brutal-card-v2--halftone">
+                    <div class="brutal-card-v2__header">
+                        <h3 class="brutal-card-v2__title">EXPORTEE</h3>
+                    </div>
+                    <div class="brutal-card-v2__content">
+                        <p class="project-card__tech">
+                            <small>Python/FastAPI • React • PostgreSQL • Docker</small>
+                        </p>
+                        <p>
+                            Self-hosted data export and transformation engine with read-only database connections,
+                            PII detection/masking, widget-based transformations, and compliance audit logging
+                            (HIPAA/FERPA/GDPR). Supports multiple export formats with optional encryption.
+                        </p>
+                        <div class="project-card__actions">
+                            <a href="https://github.com/cjunks94/exportee"
+                               class="brutal-card-v2__action"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                View on GitHub
+                            </a>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="brutal-card-v2 brutal-card-v2--halftone">
+                    <div class="brutal-card-v2__header">
                         <h3 class="brutal-card-v2__title">BB_BOUNCE</h3>
                     </div>
                     <div class="brutal-card-v2__content">


### PR DESCRIPTION
## Summary
- Add **Babble Buddy** to featured projects: embeddable AI chatbot widget (FastAPI/TypeScript/Ollama) with live demo
- Add **Exportee** to featured projects: self-hosted data export engine with PII detection (FastAPI/React)
- Position both at top of projects grid for visibility

## Test plan
- [ ] Verify project cards render correctly on portfolio page
- [ ] Test live demo link for Babble Buddy
- [ ] Test GitHub links for both projects
- [ ] Check mobile responsiveness of new cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)