### PR TITLE
feat: add blog cross-navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
                     <li><a href="#projects" class="nav-link">Projects</a></li>
                     <li><a href="#tech-radar" class="nav-link">Tech Radar</a></li>
                     <li><a href="#contact" class="nav-link">Contact</a></li>
+                    <li><a href="https://blog.cjunker.dev" class="nav-link" rel="noopener">Blog</a></li>
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- Add "Blog" link to portfolio header nav pointing to blog.cjunker.dev

Part of the blog.cjunker.dev launch — sibling site for technical writing.

## Type
- [x] Feature

## Changes
- Added `<li>` to nav list in `index.html` linking to `https://blog.cjunker.dev`

## Testing
- [ ] Blog link appears in header navigation
- [ ] Link opens blog.cjunker.dev in same tab
- [ ] Mobile hamburger menu includes Blog link
- [ ] Staging preview at staging.cjunker.dev

## Checklist
- [x] No secrets in code
- [x] Error handling complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)