### PR TITLE
chore: soft-deprecate Umami analytics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           cname: cjunker.dev
           force_orphan: true
           keep_files: true
-          exclude_assets: '.github,node_modules,tests,package*.json,.gitignore,.stylelintrc.json,.htmlvalidate.json,decisions,TODO.md,CLAUDE.md'
+          exclude_assets: '.github,node_modules,tests,package*.json,.gitignore,.stylelintrc.json,.htmlvalidate.json,decisions,TODO.md,CLAUDE.md,analytics-config.js,umami,healthcheck'
       - name: Summary
         run: |
           cat <<EOF >> $GITHUB_STEP_SUMMARY
@@ -96,7 +96,7 @@ jobs:
           cname: staging.cjunker.dev
           force_orphan: true
           keep_files: false
-          exclude_assets: '.github,node_modules,tests,package*.json,.gitignore,.stylelintrc.json,.htmlvalidate.json,decisions,TODO.md,CLAUDE.md'
+          exclude_assets: '.github,node_modules,tests,package*.json,.gitignore,.stylelintrc.json,.htmlvalidate.json,decisions,TODO.md,CLAUDE.md,analytics-config.js,umami,healthcheck'
       - name: Wait for deployment and verify CNAME
         run: |
           echo "Waiting for GitHub Pages deployment to complete..."

--- a/README.md
+++ b/README.md
@@ -12,29 +12,7 @@
 
 ## Analytics
 
-**Dashboard**: [umami.cjunker.dev](https://umami.cjunker.dev) - Self-hosted Umami analytics
-
-**Stack**:
-- **Frontend**: Privacy-friendly tracking script (no cookies, GDPR compliant)
-- **Backend**: Umami v2.13.2 in Docker (82MB Alpine-based image)
-- **Database**: PostgreSQL 16 Alpine
-- **Hosting**: Railway.app (free tier, $0/month)
-- **Security**: Cloudflare Access with GitHub OAuth (zero-trust)
-- **Features**: Custom event tracking, heatmaps, tech radar interactions
-
-**Deployment**:
-```yaml
-→ 82 MB container | 1.8s startup | Auto-HTTPS | Daily backups
-→ Zero maintenance | $0/month hosting | SOC2-ready
-```
-
-**Custom Events Tracked**:
-- Tech Radar: Click interactions, legend toggles
-- Downloads: Resume, CSV exports, documentation
-- Navigation: Page views, session analytics
-- Performance: Load times, error tracking
-
-See [umami/RAILWAY_DEPLOYMENT.md](umami/RAILWAY_DEPLOYMENT.md) for deployment guide.
+Analytics temporarily paused. Umami config preserved in `umami/` for future re-enablement. Using Railway built-in metrics in the interim.
 
 ## Project Overview
 

--- a/index.html
+++ b/index.html
@@ -89,8 +89,6 @@
         window.mermaid = mermaid;
     </script>
 
-    <!-- Umami Analytics - Environment-based tracking (see analytics-config.js) -->
-    <script src="analytics-config.js"></script>
 </head>
 <body>
     <!-- Skip navigation link for keyboard users (WCAG 2.4.1) -->


### PR DESCRIPTION
## Summary
- Remove Umami tracking script from portfolio site
- Exclude analytics-config.js, umami/, and healthcheck/ from deployments
- Preserve all Umami config in repo for future re-enablement

Using Railway built-in metrics in the interim. Umami was crashing on build (Prisma engine issue) and the maintenance cost outweighs the value for a portfolio site.

## Type
- [x] Refactor

## Changes
- `index.html`: Removed Umami script tag
- `README.md`: Updated analytics section
- `deploy.yml`: Added analytics-config.js, umami/, healthcheck/ to exclude lists (both prod and staging)

## Testing
- [ ] No analytics script in page source
- [ ] No console errors from missing tracking script
- [ ] Site loads normally without analytics overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)