### PR TITLE
feat: interactive 3D wireframe village background

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -288,7 +288,9 @@ code, pre, .mono {
         max-width: 100% !important;
     }
 
-    .no-print {
+    .no-print,
+    #village-canvas,
+    .village-toggle {
         /* Print: Hide non-printable elements */
         display: none !important;
     }

--- a/css/components.css
+++ b/css/components.css
@@ -1336,10 +1336,17 @@ body.village-active {
     background-color: transparent;
 }
 
-.village-toggle {
+.scene-toggles {
     position: fixed;
     bottom: var(--space-lg);
     left: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    z-index: var(--z-base);
+}
+
+.village-toggle {
     background: var(--c-surface);
     border: var(--border-thick) solid var(--c-border);
     padding: var(--space-xs) var(--space-sm);
@@ -1350,8 +1357,13 @@ body.village-active {
     color: var(--c-ink);
     cursor: pointer;
     box-shadow: var(--shadow-sm) var(--c-shadow);
-    z-index: var(--z-base);
     transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.village-toggle.active {
+    background: var(--c-accent);
+    color: var(--c-surface);
+    border-color: var(--c-accent);
 }
 
 .village-toggle:hover {

--- a/css/components.css
+++ b/css/components.css
@@ -1320,7 +1320,63 @@ body {
 }
 
 /* ==========================================================================
-   15. RESPONSIVE DESIGN
+   15. VILLAGE SCENE (3D Background)
+   ========================================================================== */
+#village-canvas {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -1;
+    pointer-events: auto;
+}
+
+body.village-active {
+    background-color: transparent;
+}
+
+.village-toggle {
+    position: fixed;
+    bottom: var(--space-lg);
+    left: var(--space-lg);
+    background: var(--c-surface);
+    border: var(--border-thick) solid var(--c-border);
+    padding: var(--space-xs) var(--space-sm);
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: var(--text-sm);
+    text-transform: uppercase;
+    color: var(--c-ink);
+    cursor: pointer;
+    box-shadow: var(--shadow-sm) var(--c-shadow);
+    z-index: var(--z-base);
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.village-toggle:hover {
+    transform: translate(2px, 2px);
+    box-shadow: 2px 2px 0 var(--c-shadow);
+}
+
+.village-toggle:active {
+    transform: translate(4px, 4px);
+    box-shadow: none;
+}
+
+.site-footer {
+    background: var(--c-bg);
+}
+
+@media (max-width: 768px) {
+    .village-toggle {
+        bottom: var(--space-lg);
+        left: var(--space-md);
+    }
+}
+
+/* ==========================================================================
+   16. RESPONSIVE DESIGN
    ========================================================================== */
 
 /* Tablets and up (769px+) */

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
     </script>
 
     <!-- Three.js for 3D Village Background -->
-    <script src="https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
     <script src="village-scene.js" defer></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -89,9 +89,11 @@
         window.mermaid = mermaid;
     </script>
 
-    <!-- Three.js for 3D Village Background -->
+    <!-- Three.js Background Scenes -->
     <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+    <script src="scene-manager.js" defer></script>
     <script src="village-scene.js" defer></script>
+    <script src="particle-scene.js" defer></script>
 </head>
 <body>
     <!-- Skip navigation link for keyboard users (WCAG 2.4.1) -->

--- a/index.html
+++ b/index.html
@@ -89,6 +89,9 @@
         window.mermaid = mermaid;
     </script>
 
+    <!-- Three.js for 3D Village Background -->
+    <script src="https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.min.js"></script>
+    <script src="village-scene.js" defer></script>
 </head>
 <body>
     <!-- Skip navigation link for keyboard users (WCAG 2.4.1) -->

--- a/particle-scene.js
+++ b/particle-scene.js
@@ -1,0 +1,259 @@
+/**
+ * Particle Morph Scene — Floating particles that morph between shapes.
+ * Circle → Triangle → Square with slow transitions.
+ * Mouse hover splits particles apart.
+ * Registers with SceneManager.
+ */
+(function() {
+    'use strict';
+    if (typeof THREE === 'undefined' || !window.SceneManager) return;
+
+    var PARTICLE_COUNT = 800;
+    var SHAPE_HOLD = 3.0;       // seconds to hold each shape
+    var SHAPE_TRANSITION = 2.0; // seconds to morph between shapes
+    var CYCLE_TIME = SHAPE_HOLD + SHAPE_TRANSITION;
+    var SPLIT_RADIUS = 0.15;    // normalized mouse radius for split effect
+    var SPLIT_FORCE = 3.0;      // how hard particles push away from cursor
+    var FLOAT_AMPLITUDE = 0.3;  // gentle floating motion
+
+    var scene, camera, points;
+    var positions, targets, velocities, basePositions;
+    var mouse = { x: 0, y: 0 };
+    var scrollOffset = 0;
+    var currentShape = 0;
+    var shapeTime = 0;
+    var inkColor;
+
+    // ========================================================================
+    // SHAPE GENERATORS — return array of {x, y, z} positions
+    // ========================================================================
+    function generateCircle(count, radius) {
+        var pts = [];
+        for (var i = 0; i < count; i++) {
+            var angle = (i / count) * Math.PI * 2;
+            var r = radius * (0.7 + Math.random() * 0.3);
+            pts.push({
+                x: Math.cos(angle) * r,
+                y: Math.sin(angle) * r,
+                z: (Math.random() - 0.5) * 1.5
+            });
+        }
+        return pts;
+    }
+
+    function generateTriangle(count, size) {
+        var pts = [];
+        // Three edges of a triangle
+        var verts = [
+            { x: 0, y: size * 0.8 },
+            { x: -size * 0.7, y: -size * 0.5 },
+            { x: size * 0.7, y: -size * 0.5 }
+        ];
+        for (var i = 0; i < count; i++) {
+            var edge = i % 3;
+            var t = (Math.floor(i / 3) / Math.floor(count / 3));
+            t += (Math.random() - 0.5) * 0.05;
+            var next = (edge + 1) % 3;
+            pts.push({
+                x: verts[edge].x + (verts[next].x - verts[edge].x) * t,
+                y: verts[edge].y + (verts[next].y - verts[edge].y) * t,
+                z: (Math.random() - 0.5) * 1.5
+            });
+        }
+        return pts;
+    }
+
+    function generateSquare(count, size) {
+        var pts = [];
+        var half = size * 0.6;
+        var verts = [
+            { x: -half, y: half },
+            { x: half, y: half },
+            { x: half, y: -half },
+            { x: -half, y: -half }
+        ];
+        for (var i = 0; i < count; i++) {
+            var edge = i % 4;
+            var t = (Math.floor(i / 4) / Math.floor(count / 4));
+            t += (Math.random() - 0.5) * 0.05;
+            var next = (edge + 1) % 4;
+            pts.push({
+                x: verts[edge].x + (verts[next].x - verts[edge].x) * t,
+                y: verts[edge].y + (verts[next].y - verts[edge].y) * t,
+                z: (Math.random() - 0.5) * 1.5
+            });
+        }
+        return pts;
+    }
+
+    var shapes = [generateCircle, generateTriangle, generateSquare];
+    var shapeData = [];
+
+    function buildShapeTargets() {
+        shapeData = shapes.map(function(fn) { return fn(PARTICLE_COUNT, 4); });
+    }
+
+    // ========================================================================
+    // SCENE INTERFACE
+    // ========================================================================
+    window.SceneManager.register('particles', {
+        init: function(renderer, canvas) {
+            var colors = SceneManager.getColors();
+            inkColor = new THREE.Color(colors.ink);
+
+            scene = new THREE.Scene();
+            camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 100);
+            camera.position.set(0, 0, 12);
+            camera.lookAt(0, 0, 0);
+
+            buildShapeTargets();
+
+            // Initialize particle positions to first shape
+            positions = new Float32Array(PARTICLE_COUNT * 3);
+            targets = new Float32Array(PARTICLE_COUNT * 3);
+            velocities = new Float32Array(PARTICLE_COUNT * 3);
+            basePositions = new Float32Array(PARTICLE_COUNT * 3);
+
+            var firstShape = shapeData[0];
+            for (var i = 0; i < PARTICLE_COUNT; i++) {
+                var i3 = i * 3;
+                positions[i3] = firstShape[i].x;
+                positions[i3 + 1] = firstShape[i].y;
+                positions[i3 + 2] = firstShape[i].z;
+                targets[i3] = firstShape[i].x;
+                targets[i3 + 1] = firstShape[i].y;
+                targets[i3 + 2] = firstShape[i].z;
+                basePositions[i3] = firstShape[i].x;
+                basePositions[i3 + 1] = firstShape[i].y;
+                basePositions[i3 + 2] = firstShape[i].z;
+            }
+
+            var geometry = new THREE.BufferGeometry();
+            geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+            var material = new THREE.PointsMaterial({
+                color: inkColor,
+                size: 0.06,
+                sizeAttenuation: true
+            });
+
+            points = new THREE.Points(geometry, material);
+            scene.add(points);
+
+            currentShape = 0;
+            shapeTime = 0;
+        },
+
+        animate: function(elapsed) {
+            if (!points) return;
+
+            shapeTime += 0.016;
+
+            // Determine current and next shape
+            var cyclePos = shapeTime % (CYCLE_TIME * shapes.length);
+            var shapeIndex = Math.floor(cyclePos / CYCLE_TIME);
+            var timeInCycle = cyclePos - shapeIndex * CYCLE_TIME;
+            var nextIndex = (shapeIndex + 1) % shapes.length;
+
+            // Compute morph progress (0 = current shape, 1 = next shape)
+            var morphProgress = 0;
+            if (timeInCycle > SHAPE_HOLD) {
+                morphProgress = (timeInCycle - SHAPE_HOLD) / SHAPE_TRANSITION;
+                morphProgress = morphProgress * morphProgress * (3 - 2 * morphProgress); // smoothstep
+            }
+
+            var currentData = shapeData[shapeIndex];
+            var nextData = shapeData[nextIndex];
+
+            // Update target positions (morph between shapes)
+            for (var i = 0; i < PARTICLE_COUNT; i++) {
+                var i3 = i * 3;
+                targets[i3] = currentData[i].x + (nextData[i].x - currentData[i].x) * morphProgress;
+                targets[i3 + 1] = currentData[i].y + (nextData[i].y - currentData[i].y) * morphProgress;
+                targets[i3 + 2] = currentData[i].z + (nextData[i].z - currentData[i].z) * morphProgress;
+            }
+
+            // Project mouse into 3D space for split effect
+            var mouseWorld = new THREE.Vector3(mouse.x * 6, -mouse.y * 4, 0);
+
+            // Update positions — lerp toward targets + split from mouse + float
+            for (var j = 0; j < PARTICLE_COUNT; j++) {
+                var j3 = j * 3;
+
+                // Target with floating
+                var floatX = Math.sin(elapsed * 0.5 + j * 0.1) * FLOAT_AMPLITUDE * 0.3;
+                var floatY = Math.cos(elapsed * 0.3 + j * 0.07) * FLOAT_AMPLITUDE * 0.3;
+
+                var tx = targets[j3] + floatX;
+                var ty = targets[j3 + 1] + floatY;
+                var tz = targets[j3 + 2];
+
+                // Mouse split force
+                var dx = positions[j3] - mouseWorld.x;
+                var dy = positions[j3 + 1] - mouseWorld.y;
+                var dist = Math.sqrt(dx * dx + dy * dy);
+                var splitRange = SPLIT_RADIUS * 12; // scale to world units
+
+                if (dist < splitRange && dist > 0.01) {
+                    var force = (1 - dist / splitRange) * SPLIT_FORCE;
+                    velocities[j3] += (dx / dist) * force * 0.016;
+                    velocities[j3 + 1] += (dy / dist) * force * 0.016;
+                }
+
+                // Apply velocity with damping
+                velocities[j3] *= 0.92;
+                velocities[j3 + 1] *= 0.92;
+                velocities[j3 + 2] *= 0.92;
+
+                // Lerp to target + velocity
+                positions[j3] = THREE.MathUtils.lerp(positions[j3], tx, 0.04) + velocities[j3];
+                positions[j3 + 1] = THREE.MathUtils.lerp(positions[j3 + 1], ty, 0.04) + velocities[j3 + 1];
+                positions[j3 + 2] = THREE.MathUtils.lerp(positions[j3 + 2], tz, 0.04) + velocities[j3 + 2];
+            }
+
+            points.geometry.attributes.position.needsUpdate = true;
+
+            // Subtle camera shift from scroll
+            camera.position.y = -scrollOffset * 2;
+            camera.lookAt(0, -scrollOffset * 2, 0);
+        },
+
+        onMouseMove: function(x, y) {
+            mouse.x = x;
+            mouse.y = y;
+        },
+
+        onScroll: function(offset) {
+            scrollOffset = offset;
+        },
+
+        onClick: function(x, y) {
+            // Burst — push all particles outward briefly
+            for (var i = 0; i < PARTICLE_COUNT; i++) {
+                var i3 = i * 3;
+                var dx = positions[i3] - x * 6;
+                var dy = positions[i3 + 1] + y * 4;
+                var dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                velocities[i3] += (dx / dist) * 0.5;
+                velocities[i3 + 1] += (dy / dist) * 0.5;
+            }
+        },
+
+        resize: function(w, h) {
+            if (camera) { camera.aspect = w / h; camera.updateProjectionMatrix(); }
+        },
+
+        getScene: function() { return scene; },
+        getCamera: function() { return camera; },
+
+        updateColors: function(c) {
+            inkColor = new THREE.Color(c.ink);
+            if (points) points.material.color.set(inkColor);
+        },
+
+        destroy: function() {
+            scene = null; camera = null; points = null;
+            positions = null; targets = null; velocities = null;
+        }
+    });
+})();

--- a/particle-scene.js
+++ b/particle-scene.js
@@ -8,34 +8,44 @@
     'use strict';
     if (typeof THREE === 'undefined' || !window.SceneManager) return;
 
-    var PARTICLE_COUNT = 800;
-    var SHAPE_HOLD = 3.0;       // seconds to hold each shape
-    var SHAPE_TRANSITION = 2.0; // seconds to morph between shapes
+    var PARTICLE_COUNT = 2000;
+    var SHAPE_HOLD = 3.0;
+    var SHAPE_TRANSITION = 2.0;
     var CYCLE_TIME = SHAPE_HOLD + SHAPE_TRANSITION;
-    var SPLIT_RADIUS = 0.15;    // normalized mouse radius for split effect
-    var SPLIT_FORCE = 3.0;      // how hard particles push away from cursor
-    var FLOAT_AMPLITUDE = 0.3;  // gentle floating motion
+    var SPLIT_RADIUS = 0.15;
+    var SPLIT_FORCE = 4.0;
+    var FLOAT_AMPLITUDE = 0.4;
+    var SHAPE_RADIUS = 7;       // how big the shapes are — fills margins
 
     var scene, camera, points;
-    var positions, targets, velocities, basePositions;
+    var positions, targets, velocities, particleColors;
     var mouse = { x: 0, y: 0 };
     var scrollOffset = 0;
-    var currentShape = 0;
     var shapeTime = 0;
-    var inkColor;
+
+    // Color palette — muted but varied
+    var PALETTE = [
+        new THREE.Color('#3D6649'),  // forest green (accent)
+        new THREE.Color('#5B9BD5'),  // soft blue
+        new THREE.Color('#D9534F'),  // muted red
+        new THREE.Color('#E8A838'),  // warm amber
+        new THREE.Color('#7B68A8'),  // soft purple
+        new THREE.Color('#4A7A58'),  // light green
+        new THREE.Color('#C0956C'),  // tan
+    ];
 
     // ========================================================================
-    // SHAPE GENERATORS — return array of {x, y, z} positions
+    // SHAPE GENERATORS
     // ========================================================================
     function generateCircle(count, radius) {
         var pts = [];
         for (var i = 0; i < count; i++) {
             var angle = (i / count) * Math.PI * 2;
-            var r = radius * (0.7 + Math.random() * 0.3);
+            var r = radius * (0.5 + Math.random() * 0.5);
             pts.push({
                 x: Math.cos(angle) * r,
                 y: Math.sin(angle) * r,
-                z: (Math.random() - 0.5) * 1.5
+                z: (Math.random() - 0.5) * 3
             });
         }
         return pts;
@@ -43,29 +53,42 @@
 
     function generateTriangle(count, size) {
         var pts = [];
-        // Three edges of a triangle
         var verts = [
-            { x: 0, y: size * 0.8 },
-            { x: -size * 0.7, y: -size * 0.5 },
-            { x: size * 0.7, y: -size * 0.5 }
+            { x: 0, y: size * 0.85 },
+            { x: -size * 0.75, y: -size * 0.55 },
+            { x: size * 0.75, y: -size * 0.55 }
         ];
         for (var i = 0; i < count; i++) {
             var edge = i % 3;
             var t = (Math.floor(i / 3) / Math.floor(count / 3));
-            t += (Math.random() - 0.5) * 0.05;
+            t += (Math.random() - 0.5) * 0.08;
             var next = (edge + 1) % 3;
-            pts.push({
-                x: verts[edge].x + (verts[next].x - verts[edge].x) * t,
-                y: verts[edge].y + (verts[next].y - verts[edge].y) * t,
-                z: (Math.random() - 0.5) * 1.5
-            });
+            // Fill interior too — some particles inside
+            var fill = Math.random();
+            if (fill < 0.3) {
+                // Interior point
+                var a = Math.random(), b = Math.random();
+                if (a + b > 1) { a = 1 - a; b = 1 - b; }
+                var c = 1 - a - b;
+                pts.push({
+                    x: verts[0].x * a + verts[1].x * b + verts[2].x * c,
+                    y: verts[0].y * a + verts[1].y * b + verts[2].y * c,
+                    z: (Math.random() - 0.5) * 3
+                });
+            } else {
+                pts.push({
+                    x: verts[edge].x + (verts[next].x - verts[edge].x) * t,
+                    y: verts[edge].y + (verts[next].y - verts[edge].y) * t,
+                    z: (Math.random() - 0.5) * 3
+                });
+            }
         }
         return pts;
     }
 
     function generateSquare(count, size) {
         var pts = [];
-        var half = size * 0.6;
+        var half = size * 0.65;
         var verts = [
             { x: -half, y: half },
             { x: half, y: half },
@@ -73,15 +96,25 @@
             { x: -half, y: -half }
         ];
         for (var i = 0; i < count; i++) {
-            var edge = i % 4;
-            var t = (Math.floor(i / 4) / Math.floor(count / 4));
-            t += (Math.random() - 0.5) * 0.05;
-            var next = (edge + 1) % 4;
-            pts.push({
-                x: verts[edge].x + (verts[next].x - verts[edge].x) * t,
-                y: verts[edge].y + (verts[next].y - verts[edge].y) * t,
-                z: (Math.random() - 0.5) * 1.5
-            });
+            var fill = Math.random();
+            if (fill < 0.3) {
+                // Interior
+                pts.push({
+                    x: (Math.random() - 0.5) * size * 1.2,
+                    y: (Math.random() - 0.5) * size * 1.2,
+                    z: (Math.random() - 0.5) * 3
+                });
+            } else {
+                var edge = i % 4;
+                var t = (Math.floor(i / 4) / Math.floor(count / 4));
+                t += (Math.random() - 0.5) * 0.08;
+                var next = (edge + 1) % 4;
+                pts.push({
+                    x: verts[edge].x + (verts[next].x - verts[edge].x) * t,
+                    y: verts[edge].y + (verts[next].y - verts[edge].y) * t,
+                    z: (Math.random() - 0.5) * 3
+                });
+            }
         }
         return pts;
     }
@@ -90,7 +123,7 @@
     var shapeData = [];
 
     function buildShapeTargets() {
-        shapeData = shapes.map(function(fn) { return fn(PARTICLE_COUNT, 4); });
+        shapeData = shapes.map(function(fn) { return fn(PARTICLE_COUNT, SHAPE_RADIUS); });
     }
 
     // ========================================================================
@@ -98,21 +131,17 @@
     // ========================================================================
     window.SceneManager.register('particles', {
         init: function(renderer, canvas) {
-            var colors = SceneManager.getColors();
-            inkColor = new THREE.Color(colors.ink);
-
             scene = new THREE.Scene();
             camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 100);
-            camera.position.set(0, 0, 12);
+            camera.position.set(0, 0, 18);
             camera.lookAt(0, 0, 0);
 
             buildShapeTargets();
 
-            // Initialize particle positions to first shape
             positions = new Float32Array(PARTICLE_COUNT * 3);
             targets = new Float32Array(PARTICLE_COUNT * 3);
             velocities = new Float32Array(PARTICLE_COUNT * 3);
-            basePositions = new Float32Array(PARTICLE_COUNT * 3);
+            var colorsArr = new Float32Array(PARTICLE_COUNT * 3);
 
             var firstShape = shapeData[0];
             for (var i = 0; i < PARTICLE_COUNT; i++) {
@@ -123,49 +152,50 @@
                 targets[i3] = firstShape[i].x;
                 targets[i3 + 1] = firstShape[i].y;
                 targets[i3 + 2] = firstShape[i].z;
-                basePositions[i3] = firstShape[i].x;
-                basePositions[i3 + 1] = firstShape[i].y;
-                basePositions[i3 + 2] = firstShape[i].z;
+
+                // Assign color from palette
+                var col = PALETTE[Math.floor(Math.random() * PALETTE.length)];
+                colorsArr[i3] = col.r;
+                colorsArr[i3 + 1] = col.g;
+                colorsArr[i3 + 2] = col.b;
             }
+            particleColors = colorsArr;
 
             var geometry = new THREE.BufferGeometry();
             geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+            geometry.setAttribute('color', new THREE.BufferAttribute(colorsArr, 3));
 
             var material = new THREE.PointsMaterial({
-                color: inkColor,
-                size: 0.06,
-                sizeAttenuation: true
+                size: 0.12,
+                sizeAttenuation: true,
+                vertexColors: true,
+                transparent: true,
+                opacity: 0.85
             });
 
             points = new THREE.Points(geometry, material);
             scene.add(points);
-
-            currentShape = 0;
             shapeTime = 0;
         },
 
         animate: function(elapsed) {
             if (!points) return;
-
             shapeTime += 0.016;
 
-            // Determine current and next shape
             var cyclePos = shapeTime % (CYCLE_TIME * shapes.length);
             var shapeIndex = Math.floor(cyclePos / CYCLE_TIME);
             var timeInCycle = cyclePos - shapeIndex * CYCLE_TIME;
             var nextIndex = (shapeIndex + 1) % shapes.length;
 
-            // Compute morph progress (0 = current shape, 1 = next shape)
             var morphProgress = 0;
             if (timeInCycle > SHAPE_HOLD) {
                 morphProgress = (timeInCycle - SHAPE_HOLD) / SHAPE_TRANSITION;
-                morphProgress = morphProgress * morphProgress * (3 - 2 * morphProgress); // smoothstep
+                morphProgress = morphProgress * morphProgress * (3 - 2 * morphProgress);
             }
 
             var currentData = shapeData[shapeIndex];
             var nextData = shapeData[nextIndex];
 
-            // Update target positions (morph between shapes)
             for (var i = 0; i < PARTICLE_COUNT; i++) {
                 var i3 = i * 3;
                 targets[i3] = currentData[i].x + (nextData[i].x - currentData[i].x) * morphProgress;
@@ -173,26 +203,22 @@
                 targets[i3 + 2] = currentData[i].z + (nextData[i].z - currentData[i].z) * morphProgress;
             }
 
-            // Project mouse into 3D space for split effect
-            var mouseWorld = new THREE.Vector3(mouse.x * 6, -mouse.y * 4, 0);
+            var mouseWorld = new THREE.Vector3(mouse.x * 9, -mouse.y * 7, 0);
 
-            // Update positions — lerp toward targets + split from mouse + float
             for (var j = 0; j < PARTICLE_COUNT; j++) {
                 var j3 = j * 3;
 
-                // Target with floating
-                var floatX = Math.sin(elapsed * 0.5 + j * 0.1) * FLOAT_AMPLITUDE * 0.3;
-                var floatY = Math.cos(elapsed * 0.3 + j * 0.07) * FLOAT_AMPLITUDE * 0.3;
+                var floatX = Math.sin(elapsed * 0.4 + j * 0.08) * FLOAT_AMPLITUDE * 0.4;
+                var floatY = Math.cos(elapsed * 0.25 + j * 0.06) * FLOAT_AMPLITUDE * 0.4;
 
                 var tx = targets[j3] + floatX;
                 var ty = targets[j3 + 1] + floatY;
                 var tz = targets[j3 + 2];
 
-                // Mouse split force
                 var dx = positions[j3] - mouseWorld.x;
                 var dy = positions[j3 + 1] - mouseWorld.y;
                 var dist = Math.sqrt(dx * dx + dy * dy);
-                var splitRange = SPLIT_RADIUS * 12; // scale to world units
+                var splitRange = SPLIT_RADIUS * 18;
 
                 if (dist < splitRange && dist > 0.01) {
                     var force = (1 - dist / splitRange) * SPLIT_FORCE;
@@ -200,60 +226,39 @@
                     velocities[j3 + 1] += (dy / dist) * force * 0.016;
                 }
 
-                // Apply velocity with damping
-                velocities[j3] *= 0.92;
-                velocities[j3 + 1] *= 0.92;
-                velocities[j3 + 2] *= 0.92;
+                velocities[j3] *= 0.93;
+                velocities[j3 + 1] *= 0.93;
+                velocities[j3 + 2] *= 0.93;
 
-                // Lerp to target + velocity
-                positions[j3] = THREE.MathUtils.lerp(positions[j3], tx, 0.04) + velocities[j3];
-                positions[j3 + 1] = THREE.MathUtils.lerp(positions[j3 + 1], ty, 0.04) + velocities[j3 + 1];
-                positions[j3 + 2] = THREE.MathUtils.lerp(positions[j3 + 2], tz, 0.04) + velocities[j3 + 2];
+                positions[j3] = THREE.MathUtils.lerp(positions[j3], tx, 0.035) + velocities[j3];
+                positions[j3 + 1] = THREE.MathUtils.lerp(positions[j3 + 1], ty, 0.035) + velocities[j3 + 1];
+                positions[j3 + 2] = THREE.MathUtils.lerp(positions[j3 + 2], tz, 0.035) + velocities[j3 + 2];
             }
 
             points.geometry.attributes.position.needsUpdate = true;
 
-            // Subtle camera shift from scroll
-            camera.position.y = -scrollOffset * 2;
-            camera.lookAt(0, -scrollOffset * 2, 0);
+            camera.position.y = -scrollOffset * 3;
+            camera.lookAt(0, -scrollOffset * 3, 0);
         },
 
-        onMouseMove: function(x, y) {
-            mouse.x = x;
-            mouse.y = y;
-        },
-
-        onScroll: function(offset) {
-            scrollOffset = offset;
-        },
+        onMouseMove: function(x, y) { mouse.x = x; mouse.y = y; },
+        onScroll: function(offset) { scrollOffset = offset; },
 
         onClick: function(x, y) {
-            // Burst — push all particles outward briefly
             for (var i = 0; i < PARTICLE_COUNT; i++) {
                 var i3 = i * 3;
-                var dx = positions[i3] - x * 6;
-                var dy = positions[i3 + 1] + y * 4;
+                var dx = positions[i3] - x * 9;
+                var dy = positions[i3 + 1] + y * 7;
                 var dist = Math.sqrt(dx * dx + dy * dy) || 1;
-                velocities[i3] += (dx / dist) * 0.5;
-                velocities[i3 + 1] += (dy / dist) * 0.5;
+                velocities[i3] += (dx / dist) * 0.8;
+                velocities[i3 + 1] += (dy / dist) * 0.8;
             }
         },
 
-        resize: function(w, h) {
-            if (camera) { camera.aspect = w / h; camera.updateProjectionMatrix(); }
-        },
-
+        resize: function(w, h) { if (camera) { camera.aspect = w / h; camera.updateProjectionMatrix(); } },
         getScene: function() { return scene; },
         getCamera: function() { return camera; },
-
-        updateColors: function(c) {
-            inkColor = new THREE.Color(c.ink);
-            if (points) points.material.color.set(inkColor);
-        },
-
-        destroy: function() {
-            scene = null; camera = null; points = null;
-            positions = null; targets = null; velocities = null;
-        }
+        updateColors: function() { /* particles use their own palette */ },
+        destroy: function() { scene = null; camera = null; points = null; positions = null; targets = null; velocities = null; }
     });
 })();

--- a/particle-scene.js
+++ b/particle-scene.js
@@ -15,7 +15,7 @@
     var SPLIT_RADIUS = 0.15;
     var SPLIT_FORCE = 4.0;
     var FLOAT_AMPLITUDE = 0.4;
-    var SHAPE_RADIUS = 7;       // how big the shapes are — fills margins
+    var SHAPE_RADIUS = 10;      // how big the shapes are — fills margins and beyond
 
     var scene, camera, points;
     var positions, targets, velocities, particleColors;
@@ -132,8 +132,9 @@
     window.SceneManager.register('particles', {
         init: function(renderer, canvas) {
             scene = new THREE.Scene();
-            camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 100);
-            camera.position.set(0, 0, 18);
+            scene.background = new THREE.Color('#0d1117');
+            camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 100);
+            camera.position.set(0, 0, 14);
             camera.lookAt(0, 0, 0);
 
             buildShapeTargets();
@@ -203,7 +204,7 @@
                 targets[i3 + 2] = currentData[i].z + (nextData[i].z - currentData[i].z) * morphProgress;
             }
 
-            var mouseWorld = new THREE.Vector3(mouse.x * 9, -mouse.y * 7, 0);
+            var mouseWorld = new THREE.Vector3(mouse.x * 12, -mouse.y * 9, 0);
 
             for (var j = 0; j < PARTICLE_COUNT; j++) {
                 var j3 = j * 3;
@@ -247,8 +248,8 @@
         onClick: function(x, y) {
             for (var i = 0; i < PARTICLE_COUNT; i++) {
                 var i3 = i * 3;
-                var dx = positions[i3] - x * 9;
-                var dy = positions[i3 + 1] + y * 7;
+                var dx = positions[i3] - x * 12;
+                var dy = positions[i3 + 1] + y * 9;
                 var dist = Math.sqrt(dx * dx + dy * dy) || 1;
                 velocities[i3] += (dx / dist) * 0.8;
                 velocities[i3 + 1] += (dy / dist) * 0.8;

--- a/scene-manager.js
+++ b/scene-manager.js
@@ -1,0 +1,271 @@
+/**
+ * Scene Manager
+ * Handles canvas, renderer, and switching between background scenes.
+ * Each scene registers itself via window.SceneManager.register(name, sceneObj).
+ *
+ * Scene interface:
+ *   init(renderer, canvas)  — set up scene, camera, objects
+ *   animate(elapsed)        — called each frame
+ *   onMouseMove(x, y)       — normalized mouse coords (-1 to 1)
+ *   onScroll(offset)        — 0 to 1 scroll progress
+ *   onClick(x, y)           — normalized click coords
+ *   resize(w, h)            — window resized
+ *   getScene()              — return THREE.Scene
+ *   getCamera()             — return THREE.Camera
+ *   destroy()               — cleanup
+ */
+(function() {
+    'use strict';
+
+    if (typeof THREE === 'undefined') return;
+    try {
+        var c = document.createElement('canvas');
+        if (!(c.getContext('webgl') || c.getContext('experimental-webgl'))) return;
+    } catch (e) { return; }
+
+    var scenes = {};
+    var activeScene = null;
+    var activeSceneName = null;
+    var canvas, renderer;
+    var animationId = null;
+    var isRunning = false;
+    var elapsed = 0;
+    var mouse = { x: 0, y: 0 };
+    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    // ========================================================================
+    // CANVAS & RENDERER
+    // ========================================================================
+    function initRenderer() {
+        canvas = document.createElement('canvas');
+        canvas.id = 'village-canvas';
+        canvas.setAttribute('aria-hidden', 'true');
+        canvas.setAttribute('role', 'presentation');
+        canvas.tabIndex = -1;
+        document.body.insertBefore(canvas, document.body.firstChild);
+
+        renderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: true, alpha: true });
+        renderer.setClearColor(0x000000, 0);
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        renderer.setSize(window.innerWidth, window.innerHeight);
+
+        canvas.addEventListener('webglcontextlost', function(e) {
+            e.preventDefault();
+            if (animationId) cancelAnimationFrame(animationId);
+        });
+        canvas.addEventListener('webglcontextrestored', function() {
+            if (isRunning) animate();
+        });
+    }
+
+    // ========================================================================
+    // ANIMATION LOOP
+    // ========================================================================
+    function animate() {
+        animationId = requestAnimationFrame(animate);
+        elapsed += 0.016;
+
+        if (!activeScene) return;
+
+        if (reducedMotion) {
+            renderer.render(activeScene.getScene(), activeScene.getCamera());
+            cancelAnimationFrame(animationId);
+            return;
+        }
+
+        activeScene.animate(elapsed);
+        renderer.render(activeScene.getScene(), activeScene.getCamera());
+    }
+
+    // ========================================================================
+    // SCENE SWITCHING
+    // ========================================================================
+    function switchScene(name) {
+        if (!scenes[name]) return;
+
+        if (activeScene && activeScene.destroy) {
+            activeScene.destroy();
+        }
+
+        activeSceneName = name;
+        activeScene = scenes[name];
+        activeScene.init(renderer, canvas);
+        activeScene.resize(window.innerWidth, window.innerHeight);
+        localStorage.setItem('scene-active', name);
+    }
+
+    function getSceneNames() {
+        return Object.keys(scenes);
+    }
+
+    // ========================================================================
+    // EVENT LISTENERS
+    // ========================================================================
+    function onMouseMove(e) {
+        mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
+        mouse.y = (e.clientY / window.innerHeight) * 2 - 1;
+        if (activeScene && activeScene.onMouseMove) {
+            activeScene.onMouseMove(mouse.x, mouse.y);
+        }
+    }
+
+    function onScroll() {
+        var offset = window.scrollY / (document.body.scrollHeight - window.innerHeight || 1);
+        if (activeScene && activeScene.onScroll) {
+            activeScene.onScroll(offset);
+        }
+    }
+
+    function onClick(e) {
+        var x = (e.clientX / window.innerWidth) * 2 - 1;
+        var y = -(e.clientY / window.innerHeight) * 2 + 1;
+        if (activeScene && activeScene.onClick) {
+            activeScene.onClick(x, y);
+        }
+    }
+
+    var resizeTimer;
+    function onResize() {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(function() {
+            if (!renderer) return;
+            renderer.setSize(window.innerWidth, window.innerHeight);
+            if (activeScene && activeScene.resize) {
+                activeScene.resize(window.innerWidth, window.innerHeight);
+            }
+        }, 250);
+    }
+
+    // ========================================================================
+    // TOGGLE / SWITCHER BUTTON
+    // ========================================================================
+    function createToggle() {
+        var btn = document.createElement('button');
+        btn.className = 'village-toggle';
+        btn.setAttribute('aria-label', 'Cycle background scene');
+        document.body.appendChild(btn);
+
+        function updateLabel() {
+            if (!isRunning) {
+                btn.textContent = '3D [OFF]';
+            } else {
+                btn.textContent = (activeSceneName || '').toUpperCase() + ' [ON]';
+            }
+        }
+
+        btn.addEventListener('click', function() {
+            if (!isRunning) {
+                // Turn on — resume current scene
+                startScene();
+                updateLabel();
+                return;
+            }
+
+            // Cycle to next scene, or turn off after last
+            var names = getSceneNames();
+            var idx = names.indexOf(activeSceneName);
+            var next = idx + 1;
+
+            if (next >= names.length) {
+                // Cycled through all — turn off
+                stopScene();
+                localStorage.setItem('scene-active', 'off');
+                updateLabel();
+            } else {
+                switchScene(names[next]);
+                updateLabel();
+            }
+        });
+
+        updateLabel();
+        return { btn: btn, updateLabel: updateLabel };
+    }
+
+    function startScene() {
+        if (canvas) canvas.style.display = 'block';
+        document.body.classList.add('village-active');
+        isRunning = true;
+        animate();
+    }
+
+    function stopScene() {
+        if (animationId) cancelAnimationFrame(animationId);
+        if (canvas) canvas.style.display = 'none';
+        document.body.classList.remove('village-active');
+        isRunning = false;
+    }
+
+    // ========================================================================
+    // THEME INTEGRATION
+    // ========================================================================
+    function getColors() {
+        var style = getComputedStyle(document.documentElement);
+        return {
+            ink: style.getPropertyValue('--c-ink').trim() || '#121212',
+            bg: style.getPropertyValue('--c-bg').trim() || '#f4f1de'
+        };
+    }
+
+    function onThemeChange() {
+        if (activeScene && activeScene.updateColors) {
+            activeScene.updateColors(getColors());
+        }
+    }
+
+    // ========================================================================
+    // INIT
+    // ========================================================================
+    function init() {
+        var saved = localStorage.getItem('scene-active');
+
+        initRenderer();
+        var toggle = createToggle();
+
+        // Wait for scenes to register (they load via defer too)
+        setTimeout(function() {
+            var names = getSceneNames();
+            if (names.length === 0) return;
+
+            if (saved === 'off') {
+                // Start with first scene but paused
+                switchScene(names[0]);
+                stopScene();
+                toggle.updateLabel();
+                return;
+            }
+
+            // Restore saved scene or default to first
+            var startWith = (saved && scenes[saved]) ? saved : names[0];
+            switchScene(startWith);
+
+            window.addEventListener('mousemove', onMouseMove);
+            window.addEventListener('scroll', onScroll);
+            canvas.addEventListener('click', onClick);
+            window.addEventListener('resize', onResize);
+            window.addEventListener('themechange', onThemeChange);
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', onThemeChange);
+            window.matchMedia('(prefers-reduced-motion: reduce)').addEventListener('change', function(e) {
+                reducedMotion = e.matches;
+            });
+
+            startScene();
+            toggle.updateLabel();
+        }, 50);
+    }
+
+    // ========================================================================
+    // PUBLIC API
+    // ========================================================================
+    window.SceneManager = {
+        register: function(name, sceneObj) {
+            scenes[name] = sceneObj;
+        },
+        getColors: getColors
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/scene-manager.js
+++ b/scene-manager.js
@@ -137,48 +137,48 @@
     }
 
     // ========================================================================
-    // TOGGLE / SWITCHER BUTTON
+    // SCENE TOGGLE BUTTONS (one per scene, mutually exclusive)
     // ========================================================================
-    function createToggle() {
-        var btn = document.createElement('button');
-        btn.className = 'village-toggle';
-        btn.setAttribute('aria-label', 'Cycle background scene');
-        document.body.appendChild(btn);
+    var buttons = {};
 
-        function updateLabel() {
-            if (!isRunning) {
-                btn.textContent = '3D [OFF]';
-            } else {
-                btn.textContent = (activeSceneName || '').toUpperCase() + ' [ON]';
-            }
+    function createButtons() {
+        var container = document.createElement('div');
+        container.className = 'scene-toggles';
+        document.body.appendChild(container);
+
+        function updateAll() {
+            Object.keys(buttons).forEach(function(name) {
+                var isActive = isRunning && activeSceneName === name;
+                buttons[name].textContent = name.toUpperCase() + (isActive ? ' [ON]' : '');
+                buttons[name].classList.toggle('active', isActive);
+                buttons[name].setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
         }
 
+        return { container: container, updateAll: updateAll };
+    }
+
+    function addButton(name, controls) {
+        var btn = document.createElement('button');
+        btn.className = 'village-toggle';
+        btn.setAttribute('aria-label', 'Toggle ' + name + ' background');
+        btn.setAttribute('aria-pressed', 'false');
+        btn.textContent = name.toUpperCase();
+        controls.container.appendChild(btn);
+        buttons[name] = btn;
+
         btn.addEventListener('click', function() {
-            if (!isRunning) {
-                // Turn on — resume current scene
-                startScene();
-                updateLabel();
-                return;
-            }
-
-            // Cycle to next scene, or turn off after last
-            var names = getSceneNames();
-            var idx = names.indexOf(activeSceneName);
-            var next = idx + 1;
-
-            if (next >= names.length) {
-                // Cycled through all — turn off
+            if (isRunning && activeSceneName === name) {
+                // Turn off
                 stopScene();
                 localStorage.setItem('scene-active', 'off');
-                updateLabel();
             } else {
-                switchScene(names[next]);
-                updateLabel();
+                // Switch to this scene
+                switchScene(name);
+                startScene();
             }
+            controls.updateAll();
         });
-
-        updateLabel();
-        return { btn: btn, updateLabel: updateLabel };
     }
 
     function startScene() {
@@ -219,22 +219,23 @@
         var saved = localStorage.getItem('scene-active');
 
         initRenderer();
-        var toggle = createToggle();
+        var controls = createButtons();
 
         // Wait for scenes to register (they load via defer too)
         setTimeout(function() {
             var names = getSceneNames();
             if (names.length === 0) return;
 
+            // Create a button for each registered scene
+            names.forEach(function(name) { addButton(name, controls); });
+
             if (saved === 'off') {
-                // Start with first scene but paused
                 switchScene(names[0]);
                 stopScene();
-                toggle.updateLabel();
+                controls.updateAll();
                 return;
             }
 
-            // Restore saved scene or default to first
             var startWith = (saved && scenes[saved]) ? saved : names[0];
             switchScene(startWith);
 
@@ -249,7 +250,7 @@
             });
 
             startScene();
-            toggle.updateLabel();
+            controls.updateAll();
         }, 50);
     }
 

--- a/village-scene.js
+++ b/village-scene.js
@@ -1,0 +1,599 @@
+/**
+ * 3D Wireframe Village Background
+ * Low-poly countryside scene with interactive elements.
+ * Uses Three.js (loaded via CDN).
+ */
+(function() {
+    'use strict';
+
+    // ========================================================================
+    // WEBGL CHECK & EARLY EXIT
+    // ========================================================================
+    if (typeof THREE === 'undefined') return;
+    try {
+        var c = document.createElement('canvas');
+        if (!(c.getContext('webgl') || c.getContext('experimental-webgl'))) return;
+    } catch (e) { return; }
+
+    // ========================================================================
+    // CONFIG
+    // ========================================================================
+    var CONFIG = {
+        cameraPos: { x: 0, y: 14, z: 22 },
+        orbitStrength: { x: 3, y: 1 },
+        orbitDamping: 0.03,
+        scrollParallax: 4,
+        maxPlantedTrees: 20,
+        treeGrowFrames: 20,
+        groundSize: 50,
+        groundDivisions: 25
+    };
+
+    // ========================================================================
+    // STATE
+    // ========================================================================
+    var animationId = null;
+    var isRunning = false;
+    var mouse = { x: 0, y: 0 };
+    var scrollOffset = 0;
+    var currentHovered = null;
+    var plantedTrees = [];
+    var growingTrees = [];
+    var wavingCharacters = [];
+    var allMaterials = [];
+    var windowMeshes = [];
+    var characterArms = [];
+    var scene, camera, renderer, canvas;
+    var groundPlane, solidGround;
+    var raycaster = new THREE.Raycaster();
+    var mouseVec = new THREE.Vector2();
+    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    // ========================================================================
+    // COLORS FROM CSS
+    // ========================================================================
+    function getColors() {
+        var style = getComputedStyle(document.documentElement);
+        var ink = style.getPropertyValue('--c-ink').trim() || '#121212';
+        var bg = style.getPropertyValue('--c-bg').trim() || '#f4f1de';
+        return { ink: ink, bg: bg };
+    }
+
+    function updateColors() {
+        var colors = getColors();
+        var inkColor = new THREE.Color(colors.ink);
+        allMaterials.forEach(function(m) {
+            if (m.color) m.color.set(inkColor);
+        });
+        if (solidGround) {
+            solidGround.material.color.set(new THREE.Color(colors.bg));
+        }
+    }
+
+    // ========================================================================
+    // SHARED MATERIALS
+    // ========================================================================
+    var colors = getColors();
+    var wireMat = new THREE.LineBasicMaterial({ color: colors.ink });
+    var windowMatOff = new THREE.MeshBasicMaterial({ color: colors.ink, side: THREE.DoubleSide });
+    var windowMatOn = new THREE.MeshBasicMaterial({ color: 0xffffff, side: THREE.DoubleSide });
+    allMaterials.push(wireMat);
+
+    function wireframe(geometry) {
+        return new THREE.LineSegments(new THREE.WireframeGeometry(geometry), wireMat);
+    }
+
+    // ========================================================================
+    // GEOMETRY BUILDERS
+    // ========================================================================
+    function createCottage(x, z, scale, rotation) {
+        var group = new THREE.Group();
+        group.userData.type = 'cottage';
+        var s = scale || 1;
+
+        // Body
+        var body = wireframe(new THREE.BoxGeometry(2 * s, 1.5 * s, 2 * s));
+        body.position.y = 0.75 * s;
+        group.add(body);
+
+        // Roof
+        var roof = wireframe(new THREE.ConeGeometry(1.6 * s, 1.2 * s, 4));
+        roof.position.y = (1.5 + 0.6) * s;
+        roof.rotation.y = Math.PI / 4;
+        group.add(roof);
+
+        // Door
+        var door = wireframe(new THREE.PlaneGeometry(0.4 * s, 0.7 * s));
+        door.position.set(0, 0.35 * s, 1.01 * s);
+        group.add(door);
+
+        // Windows (interactive)
+        var winGeo = new THREE.PlaneGeometry(0.3 * s, 0.3 * s);
+        var win1 = new THREE.Mesh(winGeo, windowMatOff.clone());
+        win1.position.set(-0.5 * s, 1.0 * s, 1.01 * s);
+        win1.userData.type = 'window';
+        group.add(win1);
+        windowMeshes.push(win1);
+
+        var win2 = new THREE.Mesh(winGeo, windowMatOff.clone());
+        win2.position.set(0.5 * s, 1.0 * s, 1.01 * s);
+        win2.userData.type = 'window';
+        group.add(win2);
+        windowMeshes.push(win2);
+
+        group.position.set(x, 0, z);
+        if (rotation) group.rotation.y = rotation;
+        return group;
+    }
+
+    function createTree(x, z, variant) {
+        var group = new THREE.Group();
+        group.userData.type = 'tree';
+
+        // Trunk
+        var trunk = wireframe(new THREE.CylinderGeometry(0.08, 0.12, 0.8, 5));
+        trunk.position.y = 0.4;
+        group.add(trunk);
+
+        // Canopy
+        var canopy;
+        if (variant === 'round') {
+            canopy = wireframe(new THREE.SphereGeometry(0.6, 5, 4));
+            canopy.position.y = 1.2;
+        } else {
+            canopy = wireframe(new THREE.ConeGeometry(0.5, 1.5, 6));
+            canopy.position.y = 1.55;
+        }
+        group.add(canopy);
+
+        group.position.set(x, 0, z);
+        return group;
+    }
+
+    function createGarden(x, z, rotation) {
+        var group = new THREE.Group();
+        group.userData.type = 'garden';
+
+        // Plot
+        var plot = wireframe(new THREE.PlaneGeometry(2.5, 1.5, 5, 3));
+        plot.rotation.x = -Math.PI / 2;
+        plot.position.y = 0.01;
+        group.add(plot);
+
+        // Small plants
+        for (var i = 0; i < 4; i++) {
+            var px = -0.8 + i * 0.5 + (Math.random() - 0.5) * 0.2;
+            var pz = (Math.random() - 0.5) * 0.8;
+            var bush = wireframe(new THREE.SphereGeometry(0.12, 4, 3));
+            bush.position.set(px, 0.12, pz);
+            group.add(bush);
+        }
+
+        group.position.set(x, 0, z);
+        if (rotation) group.rotation.y = rotation;
+        return group;
+    }
+
+    function createFence(startX, startZ, endX, endZ, segments) {
+        var group = new THREE.Group();
+        var count = segments || 6;
+        for (var i = 0; i <= count; i++) {
+            var t = i / count;
+            var fx = startX + (endX - startX) * t;
+            var fz = startZ + (endZ - startZ) * t;
+            var post = wireframe(new THREE.BoxGeometry(0.06, 0.4, 0.06));
+            post.position.set(fx, 0.2, fz);
+            group.add(post);
+        }
+        // Horizontal rails
+        var points = [
+            new THREE.Vector3(startX, 0.15, startZ),
+            new THREE.Vector3(endX, 0.15, endZ)
+        ];
+        var points2 = [
+            new THREE.Vector3(startX, 0.3, startZ),
+            new THREE.Vector3(endX, 0.3, endZ)
+        ];
+        var railGeo = new THREE.BufferGeometry().setFromPoints(points);
+        var railGeo2 = new THREE.BufferGeometry().setFromPoints(points2);
+        group.add(new THREE.Line(railGeo, wireMat));
+        group.add(new THREE.Line(railGeo2, wireMat));
+        return group;
+    }
+
+    function createCharacter(x, z) {
+        var group = new THREE.Group();
+        group.userData.type = 'character';
+
+        // Head
+        var head = wireframe(new THREE.SphereGeometry(0.15, 4, 3));
+        head.position.y = 1.1;
+        group.add(head);
+
+        // Body
+        var bodyPts = [new THREE.Vector3(0, 0.95, 0), new THREE.Vector3(0, 0.45, 0)];
+        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(bodyPts), wireMat));
+
+        // Left arm
+        var leftArmPts = [new THREE.Vector3(0, 0.85, 0), new THREE.Vector3(-0.25, 0.55, 0)];
+        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(leftArmPts), wireMat));
+
+        // Right arm (animatable)
+        var rightArmGroup = new THREE.Group();
+        rightArmGroup.position.set(0, 0.85, 0);
+        var armPts = [new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.25, -0.3, 0)];
+        rightArmGroup.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(armPts), wireMat));
+        rightArmGroup.userData.restZ = 0;
+        group.add(rightArmGroup);
+        characterArms.push({ arm: rightArmGroup, waving: false, parent: group });
+
+        // Legs
+        var leftLegPts = [new THREE.Vector3(0, 0.45, 0), new THREE.Vector3(-0.15, 0, 0)];
+        var rightLegPts = [new THREE.Vector3(0, 0.45, 0), new THREE.Vector3(0.15, 0, 0)];
+        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(leftLegPts), wireMat));
+        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(rightLegPts), wireMat));
+
+        group.position.set(x, 0, z);
+        return group;
+    }
+
+    function createPath(x1, z1, x2, z2) {
+        var dx = x2 - x1;
+        var dz = z2 - z1;
+        var len = Math.sqrt(dx * dx + dz * dz);
+        var path = wireframe(new THREE.PlaneGeometry(0.5, len, 1, Math.max(2, Math.floor(len))));
+        path.rotation.x = -Math.PI / 2;
+        path.position.set((x1 + x2) / 2, 0.005, (z1 + z2) / 2);
+        path.rotation.z = -Math.atan2(dz, dx) + Math.PI / 2;
+        return path;
+    }
+
+    // ========================================================================
+    // SCENE SETUP
+    // ========================================================================
+    function initScene() {
+        scene = new THREE.Scene();
+        scene.add(new THREE.AmbientLight(0xffffff, 0.8));
+
+        // Ground
+        var groundGeo = new THREE.PlaneGeometry(
+            CONFIG.groundSize, CONFIG.groundSize,
+            CONFIG.groundDivisions, CONFIG.groundDivisions
+        );
+        groundPlane = wireframe(groundGeo);
+        groundPlane.rotation.x = -Math.PI / 2;
+        groundPlane.userData.type = 'ground';
+        scene.add(groundPlane);
+
+        // Solid background plane
+        var solidGeo = new THREE.PlaneGeometry(CONFIG.groundSize * 2, CONFIG.groundSize * 2);
+        solidGround = new THREE.Mesh(solidGeo, new THREE.MeshBasicMaterial({
+            color: getColors().bg, side: THREE.DoubleSide
+        }));
+        solidGround.rotation.x = -Math.PI / 2;
+        solidGround.position.y = -0.02;
+        scene.add(solidGround);
+
+        // Cottages
+        scene.add(createCottage(-5, -3, 1, 0));
+        scene.add(createCottage(4, -4, 0.9, Math.PI / 6));
+        scene.add(createCottage(-2, 3, 1.1, -Math.PI / 8));
+        scene.add(createCottage(6, 2, 0.85, Math.PI / 3));
+
+        // Gardens (near cottages)
+        scene.add(createGarden(-3, -3, 0));
+        scene.add(createGarden(6, -4, Math.PI / 4));
+        scene.add(createGarden(-0.5, 3, Math.PI / 6));
+        scene.add(createGarden(8, 2, -Math.PI / 6));
+
+        // Trees
+        scene.add(createTree(-8, -6, 'cone'));
+        scene.add(createTree(-7, 5, 'round'));
+        scene.add(createTree(9, -2, 'cone'));
+        scene.add(createTree(10, 5, 'round'));
+        scene.add(createTree(-9, 0, 'cone'));
+        scene.add(createTree(2, 7, 'round'));
+        scene.add(createTree(-4, -8, 'cone'));
+        scene.add(createTree(7, 8, 'round'));
+
+        // Paths
+        scene.add(createPath(-5, -3, -2, 3));
+        scene.add(createPath(-2, 3, 4, -4));
+        scene.add(createPath(4, -4, 6, 2));
+
+        // Fences
+        scene.add(createFence(-7, -5, -3, -5, 5));
+        scene.add(createFence(3, 5, 8, 5, 6));
+
+        // Characters
+        scene.add(createCharacter(-1, -1));
+        scene.add(createCharacter(5, 0));
+    }
+
+    // ========================================================================
+    // RENDERER & CAMERA
+    // ========================================================================
+    function initRenderer() {
+        canvas = document.createElement('canvas');
+        canvas.id = 'village-canvas';
+        canvas.setAttribute('aria-hidden', 'true');
+        canvas.setAttribute('role', 'presentation');
+        canvas.tabIndex = -1;
+        document.body.insertBefore(canvas, document.body.firstChild);
+
+        renderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: true, alpha: true });
+        renderer.setClearColor(0x000000, 0);
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        renderer.setSize(window.innerWidth, window.innerHeight);
+
+        camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
+        camera.position.set(CONFIG.cameraPos.x, CONFIG.cameraPos.y, CONFIG.cameraPos.z);
+        camera.lookAt(0, 0, 0);
+
+        // Context loss handling
+        canvas.addEventListener('webglcontextlost', function(e) {
+            e.preventDefault();
+            if (animationId) cancelAnimationFrame(animationId);
+        });
+        canvas.addEventListener('webglcontextrestored', function() {
+            animate();
+        });
+    }
+
+    // ========================================================================
+    // INTERACTIONS
+    // ========================================================================
+    function onMouseMove(e) {
+        mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
+        mouse.y = (e.clientY / window.innerHeight) * 2 - 1;
+        mouseVec.set(mouse.x, -mouse.y);
+    }
+
+    function onScroll() {
+        scrollOffset = window.scrollY / (document.body.scrollHeight - window.innerHeight || 1);
+    }
+
+    function onClick(e) {
+        var clickMouse = new THREE.Vector2(
+            (e.clientX / window.innerWidth) * 2 - 1,
+            -(e.clientY / window.innerHeight) * 2 + 1
+        );
+        raycaster.setFromCamera(clickMouse, camera);
+
+        // Only intersect ground
+        var hits = raycaster.intersectObject(solidGround);
+        if (hits.length > 0) {
+            var pt = hits[0].point;
+            var variant = Math.random() > 0.5 ? 'cone' : 'round';
+            var tree = createTree(pt.x, pt.z, variant);
+            tree.scale.set(0, 0, 0);
+            scene.add(tree);
+            growingTrees.push({ obj: tree, frame: 0 });
+            plantedTrees.push(tree);
+
+            // Cap at max
+            if (plantedTrees.length > CONFIG.maxPlantedTrees) {
+                var old = plantedTrees.shift();
+                scene.remove(old);
+            }
+        }
+    }
+
+    function checkHover() {
+        raycaster.setFromCamera(mouseVec, camera);
+
+        // Check cottages
+        var cottages = [];
+        var characters = [];
+        scene.traverse(function(obj) {
+            if (obj.userData.type === 'cottage') cottages.push(obj);
+            if (obj.userData.type === 'character') characters.push(obj);
+        });
+
+        // Cottage hover
+        var cottageHit = false;
+        for (var i = 0; i < cottages.length; i++) {
+            var hits = raycaster.intersectObjects(cottages[i].children, true);
+            if (hits.length > 0) {
+                if (currentHovered !== cottages[i]) {
+                    unhoverAll();
+                    currentHovered = cottages[i];
+                    cottages[i].traverse(function(child) {
+                        if (child.userData.type === 'window') {
+                            child.material = windowMatOn;
+                        }
+                    });
+                }
+                cottageHit = true;
+                break;
+            }
+        }
+
+        // Character hover
+        if (!cottageHit) {
+            var charHit = false;
+            for (var j = 0; j < characters.length; j++) {
+                var charHits = raycaster.intersectObjects(characters[j].children, true);
+                if (charHits.length > 0) {
+                    if (currentHovered !== characters[j]) {
+                        unhoverAll();
+                        currentHovered = characters[j];
+                        characterArms.forEach(function(ca) {
+                            if (ca.parent === characters[j]) ca.waving = true;
+                        });
+                    }
+                    charHit = true;
+                    break;
+                }
+            }
+            if (!charHit && currentHovered) {
+                unhoverAll();
+            }
+        }
+    }
+
+    function unhoverAll() {
+        if (currentHovered) {
+            currentHovered.traverse(function(child) {
+                if (child.userData.type === 'window') {
+                    child.material = windowMatOff;
+                }
+            });
+            characterArms.forEach(function(ca) { ca.waving = false; });
+            currentHovered = null;
+        }
+    }
+
+    // ========================================================================
+    // ANIMATION LOOP
+    // ========================================================================
+    var elapsed = 0;
+    function animate() {
+        animationId = requestAnimationFrame(animate);
+        elapsed += 0.016;
+
+        if (reducedMotion) {
+            renderer.render(scene, camera);
+            cancelAnimationFrame(animationId);
+            return;
+        }
+
+        // Camera orbit
+        var targetX = CONFIG.cameraPos.x + mouse.x * CONFIG.orbitStrength.x;
+        var targetY = CONFIG.cameraPos.y - mouse.y * CONFIG.orbitStrength.y;
+        var targetZ = CONFIG.cameraPos.z - scrollOffset * CONFIG.scrollParallax;
+        camera.position.x = THREE.MathUtils.lerp(camera.position.x, targetX, CONFIG.orbitDamping);
+        camera.position.y = THREE.MathUtils.lerp(camera.position.y, targetY, CONFIG.orbitDamping);
+        camera.position.z = THREE.MathUtils.lerp(camera.position.z, targetZ, CONFIG.orbitDamping);
+        camera.lookAt(0, 0, 0);
+
+        // Hover check (every other frame for perf)
+        if (Math.floor(elapsed * 60) % 2 === 0) {
+            checkHover();
+        }
+
+        // Character wave animation
+        characterArms.forEach(function(ca) {
+            if (ca.waving) {
+                ca.arm.rotation.z = Math.sin(elapsed * 8) * 0.6;
+            } else {
+                ca.arm.rotation.z = THREE.MathUtils.lerp(ca.arm.rotation.z, 0, 0.1);
+            }
+        });
+
+        // Growing trees
+        for (var i = growingTrees.length - 1; i >= 0; i--) {
+            var gt = growingTrees[i];
+            gt.frame++;
+            var progress = Math.min(gt.frame / CONFIG.treeGrowFrames, 1);
+            var eased = 1 - Math.pow(1 - progress, 3);
+            gt.obj.scale.set(eased, eased, eased);
+            if (progress >= 1) growingTrees.splice(i, 1);
+        }
+
+        renderer.render(scene, camera);
+    }
+
+    // ========================================================================
+    // TOGGLE BUTTON
+    // ========================================================================
+    function createToggle() {
+        var btn = document.createElement('button');
+        btn.className = 'village-toggle';
+        btn.setAttribute('aria-label', 'Toggle 3D village background');
+        btn.setAttribute('aria-pressed', 'true');
+        btn.textContent = '3D [ON]';
+        document.body.appendChild(btn);
+
+        btn.addEventListener('click', function() {
+            if (isRunning) {
+                stopScene();
+                btn.textContent = '3D [OFF]';
+                btn.setAttribute('aria-pressed', 'false');
+                localStorage.setItem('village-scene-enabled', 'false');
+            } else {
+                startScene();
+                btn.textContent = '3D [ON]';
+                btn.setAttribute('aria-pressed', 'true');
+                localStorage.setItem('village-scene-enabled', 'true');
+            }
+        });
+
+        return btn;
+    }
+
+    function startScene() {
+        if (canvas) canvas.style.display = 'block';
+        document.body.classList.add('village-active');
+        isRunning = true;
+        animate();
+    }
+
+    function stopScene() {
+        if (animationId) cancelAnimationFrame(animationId);
+        if (canvas) canvas.style.display = 'none';
+        document.body.classList.remove('village-active');
+        isRunning = false;
+    }
+
+    // ========================================================================
+    // RESIZE
+    // ========================================================================
+    var resizeTimer;
+    function onResize() {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(function() {
+            if (!renderer) return;
+            camera.aspect = window.innerWidth / window.innerHeight;
+            camera.updateProjectionMatrix();
+            renderer.setSize(window.innerWidth, window.innerHeight);
+        }, 250);
+    }
+
+    // ========================================================================
+    // INIT
+    // ========================================================================
+    function init() {
+        var savedState = localStorage.getItem('village-scene-enabled');
+        if (savedState === 'false') {
+            var btn = createToggle();
+            btn.textContent = '3D [OFF]';
+            btn.setAttribute('aria-pressed', 'false');
+            return;
+        }
+
+        initScene();
+        initRenderer();
+        createToggle();
+
+        // Event listeners
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('scroll', onScroll);
+        canvas.addEventListener('click', onClick);
+        window.addEventListener('resize', onResize);
+
+        // Theme changes
+        window.addEventListener('themechange', updateColors);
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateColors);
+
+        // Reduced motion
+        window.matchMedia('(prefers-reduced-motion: reduce)').addEventListener('change', function(e) {
+            reducedMotion = e.matches;
+            if (reducedMotion && isRunning) {
+                renderer.render(scene, camera);
+                cancelAnimationFrame(animationId);
+            } else if (!reducedMotion && isRunning) {
+                animate();
+            }
+        });
+
+        startScene();
+    }
+
+    // Wait for DOM
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/village-scene.js
+++ b/village-scene.js
@@ -1,23 +1,11 @@
 /**
- * 3D Wireframe Village Background
- * Low-poly countryside scene with interactive elements.
- * Uses Three.js (loaded via CDN).
+ * Village Scene — Low-poly wireframe countryside
+ * Registers with SceneManager.
  */
 (function() {
     'use strict';
+    if (typeof THREE === 'undefined' || !window.SceneManager) return;
 
-    // ========================================================================
-    // WEBGL CHECK & EARLY EXIT
-    // ========================================================================
-    if (typeof THREE === 'undefined') return;
-    try {
-        var c = document.createElement('canvas');
-        if (!(c.getContext('webgl') || c.getContext('experimental-webgl'))) return;
-    } catch (e) { return; }
-
-    // ========================================================================
-    // CONFIG
-    // ========================================================================
     var CONFIG = {
         cameraPos: { x: 0, y: 14, z: 22 },
         orbitStrength: { x: 3, y: 1 },
@@ -29,571 +17,170 @@
         groundDivisions: 25
     };
 
-    // ========================================================================
-    // STATE
-    // ========================================================================
-    var animationId = null;
-    var isRunning = false;
+    var scene, camera;
     var mouse = { x: 0, y: 0 };
     var scrollOffset = 0;
     var currentHovered = null;
     var plantedTrees = [];
     var growingTrees = [];
-    var wavingCharacters = [];
     var allMaterials = [];
     var windowMeshes = [];
     var characterArms = [];
-    var scene, camera, renderer, canvas;
-    var groundPlane, solidGround;
+    var solidGround;
     var raycaster = new THREE.Raycaster();
     var mouseVec = new THREE.Vector2();
-    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    // ========================================================================
-    // COLORS FROM CSS
-    // ========================================================================
-    function getColors() {
-        var style = getComputedStyle(document.documentElement);
-        var ink = style.getPropertyValue('--c-ink').trim() || '#121212';
-        var bg = style.getPropertyValue('--c-bg').trim() || '#f4f1de';
-        return { ink: ink, bg: bg };
-    }
-
-    function updateColors() {
-        var colors = getColors();
-        var inkColor = new THREE.Color(colors.ink);
-        allMaterials.forEach(function(m) {
-            if (m.color) m.color.set(inkColor);
-        });
-        if (solidGround) {
-            solidGround.material.color.set(new THREE.Color(colors.bg));
-        }
-    }
-
-    // ========================================================================
-    // SHARED MATERIALS
-    // ========================================================================
-    var colors = getColors();
+    var colors = SceneManager.getColors();
     var wireMat = new THREE.LineBasicMaterial({ color: colors.ink });
     var windowMatOff = new THREE.MeshBasicMaterial({ color: colors.ink, side: THREE.DoubleSide });
     var windowMatOn = new THREE.MeshBasicMaterial({ color: 0xffffff, side: THREE.DoubleSide });
     allMaterials.push(wireMat);
 
-    function wireframe(geometry) {
-        return new THREE.LineSegments(new THREE.WireframeGeometry(geometry), wireMat);
+    function wireframe(geo) {
+        return new THREE.LineSegments(new THREE.WireframeGeometry(geo), wireMat);
     }
 
-    // ========================================================================
-    // GEOMETRY BUILDERS
-    // ========================================================================
+    // --- Geometry builders (unchanged) ---
     function createCottage(x, z, scale, rotation) {
-        var group = new THREE.Group();
-        group.userData.type = 'cottage';
-        var s = scale || 1;
-
-        // Body
-        var body = wireframe(new THREE.BoxGeometry(2 * s, 1.5 * s, 2 * s));
-        body.position.y = 0.75 * s;
-        group.add(body);
-
-        // Roof
-        var roof = wireframe(new THREE.ConeGeometry(1.6 * s, 1.2 * s, 4));
-        roof.position.y = (1.5 + 0.6) * s;
-        roof.rotation.y = Math.PI / 4;
-        group.add(roof);
-
-        // Door
-        var door = wireframe(new THREE.PlaneGeometry(0.4 * s, 0.7 * s));
-        door.position.set(0, 0.35 * s, 1.01 * s);
-        group.add(door);
-
-        // Windows (interactive)
-        var winGeo = new THREE.PlaneGeometry(0.3 * s, 0.3 * s);
-        var win1 = new THREE.Mesh(winGeo, windowMatOff.clone());
-        win1.position.set(-0.5 * s, 1.0 * s, 1.01 * s);
-        win1.userData.type = 'window';
-        group.add(win1);
-        windowMeshes.push(win1);
-
-        var win2 = new THREE.Mesh(winGeo, windowMatOff.clone());
-        win2.position.set(0.5 * s, 1.0 * s, 1.01 * s);
-        win2.userData.type = 'window';
-        group.add(win2);
-        windowMeshes.push(win2);
-
-        group.position.set(x, 0, z);
-        if (rotation) group.rotation.y = rotation;
-        return group;
+        var g = new THREE.Group(); g.userData.type = 'cottage'; var s = scale || 1;
+        var body = wireframe(new THREE.BoxGeometry(2*s, 1.5*s, 2*s)); body.position.y = 0.75*s; g.add(body);
+        var roof = wireframe(new THREE.ConeGeometry(1.6*s, 1.2*s, 4)); roof.position.y = (1.5+0.6)*s; roof.rotation.y = Math.PI/4; g.add(roof);
+        var door = wireframe(new THREE.PlaneGeometry(0.4*s, 0.7*s)); door.position.set(0, 0.35*s, 1.01*s); g.add(door);
+        var winGeo = new THREE.PlaneGeometry(0.3*s, 0.3*s);
+        var w1 = new THREE.Mesh(winGeo, windowMatOff.clone()); w1.position.set(-0.5*s, 1.0*s, 1.01*s); w1.userData.type = 'window'; g.add(w1); windowMeshes.push(w1);
+        var w2 = new THREE.Mesh(winGeo, windowMatOff.clone()); w2.position.set(0.5*s, 1.0*s, 1.01*s); w2.userData.type = 'window'; g.add(w2); windowMeshes.push(w2);
+        g.position.set(x, 0, z); if (rotation) g.rotation.y = rotation; return g;
     }
 
     function createTree(x, z, variant) {
-        var group = new THREE.Group();
-        group.userData.type = 'tree';
-
-        // Trunk
-        var trunk = wireframe(new THREE.CylinderGeometry(0.08, 0.12, 0.8, 5));
-        trunk.position.y = 0.4;
-        group.add(trunk);
-
-        // Canopy
-        var canopy;
-        if (variant === 'round') {
-            canopy = wireframe(new THREE.SphereGeometry(0.6, 5, 4));
-            canopy.position.y = 1.2;
-        } else {
-            canopy = wireframe(new THREE.ConeGeometry(0.5, 1.5, 6));
-            canopy.position.y = 1.55;
-        }
-        group.add(canopy);
-
-        group.position.set(x, 0, z);
-        return group;
+        var g = new THREE.Group(); g.userData.type = 'tree';
+        var trunk = wireframe(new THREE.CylinderGeometry(0.08, 0.12, 0.8, 5)); trunk.position.y = 0.4; g.add(trunk);
+        if (variant === 'round') { var c = wireframe(new THREE.SphereGeometry(0.6, 5, 4)); c.position.y = 1.2; g.add(c); }
+        else { var c = wireframe(new THREE.ConeGeometry(0.5, 1.5, 6)); c.position.y = 1.55; g.add(c); }
+        g.position.set(x, 0, z); return g;
     }
 
     function createGarden(x, z, rotation) {
-        var group = new THREE.Group();
-        group.userData.type = 'garden';
-
-        // Plot
-        var plot = wireframe(new THREE.PlaneGeometry(2.5, 1.5, 5, 3));
-        plot.rotation.x = -Math.PI / 2;
-        plot.position.y = 0.01;
-        group.add(plot);
-
-        // Small plants
+        var g = new THREE.Group(); g.userData.type = 'garden';
+        var plot = wireframe(new THREE.PlaneGeometry(2.5, 1.5, 5, 3)); plot.rotation.x = -Math.PI/2; plot.position.y = 0.01; g.add(plot);
         for (var i = 0; i < 4; i++) {
-            var px = -0.8 + i * 0.5 + (Math.random() - 0.5) * 0.2;
-            var pz = (Math.random() - 0.5) * 0.8;
             var bush = wireframe(new THREE.SphereGeometry(0.12, 4, 3));
-            bush.position.set(px, 0.12, pz);
-            group.add(bush);
+            bush.position.set(-0.8 + i*0.5 + (Math.random()-0.5)*0.2, 0.12, (Math.random()-0.5)*0.8); g.add(bush);
         }
-
-        group.position.set(x, 0, z);
-        if (rotation) group.rotation.y = rotation;
-        return group;
+        g.position.set(x, 0, z); if (rotation) g.rotation.y = rotation; return g;
     }
 
-    function createFence(startX, startZ, endX, endZ, segments) {
-        var group = new THREE.Group();
-        var count = segments || 6;
-        for (var i = 0; i <= count; i++) {
-            var t = i / count;
-            var fx = startX + (endX - startX) * t;
-            var fz = startZ + (endZ - startZ) * t;
-            var post = wireframe(new THREE.BoxGeometry(0.06, 0.4, 0.06));
-            post.position.set(fx, 0.2, fz);
-            group.add(post);
-        }
-        // Horizontal rails
-        var points = [
-            new THREE.Vector3(startX, 0.15, startZ),
-            new THREE.Vector3(endX, 0.15, endZ)
-        ];
-        var points2 = [
-            new THREE.Vector3(startX, 0.3, startZ),
-            new THREE.Vector3(endX, 0.3, endZ)
-        ];
-        var railGeo = new THREE.BufferGeometry().setFromPoints(points);
-        var railGeo2 = new THREE.BufferGeometry().setFromPoints(points2);
-        group.add(new THREE.Line(railGeo, wireMat));
-        group.add(new THREE.Line(railGeo2, wireMat));
-        return group;
+    function createFence(sx, sz, ex, ez, segs) {
+        var g = new THREE.Group(); var n = segs || 6;
+        for (var i = 0; i <= n; i++) { var t = i/n; var post = wireframe(new THREE.BoxGeometry(0.06, 0.4, 0.06)); post.position.set(sx+(ex-sx)*t, 0.2, sz+(ez-sz)*t); g.add(post); }
+        g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(sx,0.15,sz), new THREE.Vector3(ex,0.15,ez)]), wireMat));
+        g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(sx,0.3,sz), new THREE.Vector3(ex,0.3,ez)]), wireMat));
+        return g;
     }
 
     function createCharacter(x, z) {
-        var group = new THREE.Group();
-        group.userData.type = 'character';
-
-        // Head
-        var head = wireframe(new THREE.SphereGeometry(0.15, 4, 3));
-        head.position.y = 1.1;
-        group.add(head);
-
-        // Body
-        var bodyPts = [new THREE.Vector3(0, 0.95, 0), new THREE.Vector3(0, 0.45, 0)];
-        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(bodyPts), wireMat));
-
-        // Left arm
-        var leftArmPts = [new THREE.Vector3(0, 0.85, 0), new THREE.Vector3(-0.25, 0.55, 0)];
-        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(leftArmPts), wireMat));
-
-        // Right arm (animatable)
-        var rightArmGroup = new THREE.Group();
-        rightArmGroup.position.set(0, 0.85, 0);
-        var armPts = [new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.25, -0.3, 0)];
-        rightArmGroup.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(armPts), wireMat));
-        rightArmGroup.userData.restZ = 0;
-        group.add(rightArmGroup);
-        characterArms.push({ arm: rightArmGroup, waving: false, parent: group });
-
-        // Legs
-        var leftLegPts = [new THREE.Vector3(0, 0.45, 0), new THREE.Vector3(-0.15, 0, 0)];
-        var rightLegPts = [new THREE.Vector3(0, 0.45, 0), new THREE.Vector3(0.15, 0, 0)];
-        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(leftLegPts), wireMat));
-        group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(rightLegPts), wireMat));
-
-        group.position.set(x, 0, z);
-        return group;
+        var g = new THREE.Group(); g.userData.type = 'character';
+        var head = wireframe(new THREE.SphereGeometry(0.15, 4, 3)); head.position.y = 1.1; g.add(head);
+        g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0.95,0), new THREE.Vector3(0,0.45,0)]), wireMat));
+        g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0.85,0), new THREE.Vector3(-0.25,0.55,0)]), wireMat));
+        var arm = new THREE.Group(); arm.position.set(0, 0.85, 0);
+        arm.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0,0), new THREE.Vector3(0.25,-0.3,0)]), wireMat));
+        g.add(arm); characterArms.push({ arm: arm, waving: false, parent: g });
+        g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0.45,0), new THREE.Vector3(-0.15,0,0)]), wireMat));
+        g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0,0.45,0), new THREE.Vector3(0.15,0,0)]), wireMat));
+        g.position.set(x, 0, z); return g;
     }
 
     function createPath(x1, z1, x2, z2) {
-        var dx = x2 - x1;
-        var dz = z2 - z1;
-        var len = Math.sqrt(dx * dx + dz * dz);
-        var path = wireframe(new THREE.PlaneGeometry(0.5, len, 1, Math.max(2, Math.floor(len))));
-        path.rotation.x = -Math.PI / 2;
-        path.position.set((x1 + x2) / 2, 0.005, (z1 + z2) / 2);
-        path.rotation.z = -Math.atan2(dz, dx) + Math.PI / 2;
-        return path;
+        var dx = x2-x1, dz = z2-z1, len = Math.sqrt(dx*dx+dz*dz);
+        var p = wireframe(new THREE.PlaneGeometry(0.5, len, 1, Math.max(2, Math.floor(len))));
+        p.rotation.x = -Math.PI/2; p.position.set((x1+x2)/2, 0.005, (z1+z2)/2); p.rotation.z = -Math.atan2(dz, dx) + Math.PI/2; return p;
     }
 
-    // ========================================================================
-    // SCENE SETUP
-    // ========================================================================
-    function initScene() {
-        scene = new THREE.Scene();
-        scene.add(new THREE.AmbientLight(0xffffff, 0.8));
-
-        // Ground
-        var groundGeo = new THREE.PlaneGeometry(
-            CONFIG.groundSize, CONFIG.groundSize,
-            CONFIG.groundDivisions, CONFIG.groundDivisions
-        );
-        groundPlane = wireframe(groundGeo);
-        groundPlane.rotation.x = -Math.PI / 2;
-        groundPlane.userData.type = 'ground';
-        scene.add(groundPlane);
-
-        // Solid background plane
-        var solidGeo = new THREE.PlaneGeometry(CONFIG.groundSize * 2, CONFIG.groundSize * 2);
-        solidGround = new THREE.Mesh(solidGeo, new THREE.MeshBasicMaterial({
-            color: getColors().bg, side: THREE.DoubleSide
-        }));
-        solidGround.rotation.x = -Math.PI / 2;
-        solidGround.position.y = -0.02;
-        scene.add(solidGround);
-
-        // Cottages
-        scene.add(createCottage(-5, -3, 1, 0));
-        scene.add(createCottage(4, -4, 0.9, Math.PI / 6));
-        scene.add(createCottage(-2, 3, 1.1, -Math.PI / 8));
-        scene.add(createCottage(6, 2, 0.85, Math.PI / 3));
-
-        // Gardens (near cottages)
-        scene.add(createGarden(-3, -3, 0));
-        scene.add(createGarden(6, -4, Math.PI / 4));
-        scene.add(createGarden(-0.5, 3, Math.PI / 6));
-        scene.add(createGarden(8, 2, -Math.PI / 6));
-
-        // Trees
-        scene.add(createTree(-8, -6, 'cone'));
-        scene.add(createTree(-7, 5, 'round'));
-        scene.add(createTree(9, -2, 'cone'));
-        scene.add(createTree(10, 5, 'round'));
-        scene.add(createTree(-9, 0, 'cone'));
-        scene.add(createTree(2, 7, 'round'));
-        scene.add(createTree(-4, -8, 'cone'));
-        scene.add(createTree(7, 8, 'round'));
-
-        // Paths
-        scene.add(createPath(-5, -3, -2, 3));
-        scene.add(createPath(-2, 3, 4, -4));
-        scene.add(createPath(4, -4, 6, 2));
-
-        // Fences
-        scene.add(createFence(-7, -5, -3, -5, 5));
-        scene.add(createFence(3, 5, 8, 5, 6));
-
-        // Characters
-        scene.add(createCharacter(-1, -1));
-        scene.add(createCharacter(5, 0));
-    }
-
-    // ========================================================================
-    // RENDERER & CAMERA
-    // ========================================================================
-    function initRenderer() {
-        canvas = document.createElement('canvas');
-        canvas.id = 'village-canvas';
-        canvas.setAttribute('aria-hidden', 'true');
-        canvas.setAttribute('role', 'presentation');
-        canvas.tabIndex = -1;
-        document.body.insertBefore(canvas, document.body.firstChild);
-
-        renderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: true, alpha: true });
-        renderer.setClearColor(0x000000, 0);
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        renderer.setSize(window.innerWidth, window.innerHeight);
-
-        camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
-        camera.position.set(CONFIG.cameraPos.x, CONFIG.cameraPos.y, CONFIG.cameraPos.z);
-        camera.lookAt(0, 0, 0);
-
-        // Context loss handling
-        canvas.addEventListener('webglcontextlost', function(e) {
-            e.preventDefault();
-            if (animationId) cancelAnimationFrame(animationId);
-        });
-        canvas.addEventListener('webglcontextrestored', function() {
-            animate();
-        });
-    }
-
-    // ========================================================================
-    // INTERACTIONS
-    // ========================================================================
-    function onMouseMove(e) {
-        mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
-        mouse.y = (e.clientY / window.innerHeight) * 2 - 1;
-        mouseVec.set(mouse.x, -mouse.y);
-    }
-
-    function onScroll() {
-        scrollOffset = window.scrollY / (document.body.scrollHeight - window.innerHeight || 1);
-    }
-
-    function onClick(e) {
-        var clickMouse = new THREE.Vector2(
-            (e.clientX / window.innerWidth) * 2 - 1,
-            -(e.clientY / window.innerHeight) * 2 + 1
-        );
-        raycaster.setFromCamera(clickMouse, camera);
-
-        // Only intersect ground
-        var hits = raycaster.intersectObject(solidGround);
-        if (hits.length > 0) {
-            var pt = hits[0].point;
-            var variant = Math.random() > 0.5 ? 'cone' : 'round';
-            var tree = createTree(pt.x, pt.z, variant);
-            tree.scale.set(0, 0, 0);
-            scene.add(tree);
-            growingTrees.push({ obj: tree, frame: 0 });
-            plantedTrees.push(tree);
-
-            // Cap at max
-            if (plantedTrees.length > CONFIG.maxPlantedTrees) {
-                var old = plantedTrees.shift();
-                scene.remove(old);
-            }
-        }
+    function unhoverAll() {
+        if (!currentHovered) return;
+        currentHovered.traverse(function(c) { if (c.userData.type === 'window') c.material = windowMatOff; });
+        characterArms.forEach(function(ca) { ca.waving = false; });
+        currentHovered = null;
     }
 
     function checkHover() {
         raycaster.setFromCamera(mouseVec, camera);
+        var cottages = [], characters = [];
+        scene.traverse(function(o) { if (o.userData.type === 'cottage') cottages.push(o); if (o.userData.type === 'character') characters.push(o); });
 
-        // Check cottages
-        var cottages = [];
-        var characters = [];
-        scene.traverse(function(obj) {
-            if (obj.userData.type === 'cottage') cottages.push(obj);
-            if (obj.userData.type === 'character') characters.push(obj);
-        });
-
-        // Cottage hover
-        var cottageHit = false;
+        var hit = false;
         for (var i = 0; i < cottages.length; i++) {
-            var hits = raycaster.intersectObjects(cottages[i].children, true);
-            if (hits.length > 0) {
-                if (currentHovered !== cottages[i]) {
-                    unhoverAll();
-                    currentHovered = cottages[i];
-                    cottages[i].traverse(function(child) {
-                        if (child.userData.type === 'window') {
-                            child.material = windowMatOn;
-                        }
-                    });
-                }
-                cottageHit = true;
-                break;
+            if (raycaster.intersectObjects(cottages[i].children, true).length > 0) {
+                if (currentHovered !== cottages[i]) { unhoverAll(); currentHovered = cottages[i]; cottages[i].traverse(function(c) { if (c.userData.type === 'window') c.material = windowMatOn; }); }
+                hit = true; break;
             }
         }
-
-        // Character hover
-        if (!cottageHit) {
-            var charHit = false;
+        if (!hit) {
             for (var j = 0; j < characters.length; j++) {
-                var charHits = raycaster.intersectObjects(characters[j].children, true);
-                if (charHits.length > 0) {
-                    if (currentHovered !== characters[j]) {
-                        unhoverAll();
-                        currentHovered = characters[j];
-                        characterArms.forEach(function(ca) {
-                            if (ca.parent === characters[j]) ca.waving = true;
-                        });
-                    }
-                    charHit = true;
-                    break;
+                if (raycaster.intersectObjects(characters[j].children, true).length > 0) {
+                    if (currentHovered !== characters[j]) { unhoverAll(); currentHovered = characters[j]; characterArms.forEach(function(ca) { if (ca.parent === characters[j]) ca.waving = true; }); }
+                    hit = true; break;
                 }
             }
-            if (!charHit && currentHovered) {
-                unhoverAll();
+        }
+        if (!hit) unhoverAll();
+    }
+
+    // --- Scene interface for SceneManager ---
+    window.SceneManager.register('village', {
+        init: function(renderer, canvas) {
+            scene = new THREE.Scene();
+            scene.add(new THREE.AmbientLight(0xffffff, 0.8));
+            var gGeo = new THREE.PlaneGeometry(CONFIG.groundSize, CONFIG.groundSize, CONFIG.groundDivisions, CONFIG.groundDivisions);
+            var gp = wireframe(gGeo); gp.rotation.x = -Math.PI/2; gp.userData.type = 'ground'; scene.add(gp);
+            var sGeo = new THREE.PlaneGeometry(CONFIG.groundSize*2, CONFIG.groundSize*2);
+            solidGround = new THREE.Mesh(sGeo, new THREE.MeshBasicMaterial({ color: SceneManager.getColors().bg, side: THREE.DoubleSide }));
+            solidGround.rotation.x = -Math.PI/2; solidGround.position.y = -0.02; scene.add(solidGround);
+
+            scene.add(createCottage(-5,-3,1,0)); scene.add(createCottage(4,-4,0.9,Math.PI/6)); scene.add(createCottage(-2,3,1.1,-Math.PI/8)); scene.add(createCottage(6,2,0.85,Math.PI/3));
+            scene.add(createGarden(-3,-3,0)); scene.add(createGarden(6,-4,Math.PI/4)); scene.add(createGarden(-0.5,3,Math.PI/6)); scene.add(createGarden(8,2,-Math.PI/6));
+            scene.add(createTree(-8,-6,'cone')); scene.add(createTree(-7,5,'round')); scene.add(createTree(9,-2,'cone')); scene.add(createTree(10,5,'round'));
+            scene.add(createTree(-9,0,'cone')); scene.add(createTree(2,7,'round')); scene.add(createTree(-4,-8,'cone')); scene.add(createTree(7,8,'round'));
+            scene.add(createPath(-5,-3,-2,3)); scene.add(createPath(-2,3,4,-4)); scene.add(createPath(4,-4,6,2));
+            scene.add(createFence(-7,-5,-3,-5,5)); scene.add(createFence(3,5,8,5,6));
+            scene.add(createCharacter(-1,-1)); scene.add(createCharacter(5,0));
+
+            camera = new THREE.PerspectiveCamera(45, window.innerWidth/window.innerHeight, 0.1, 100);
+            camera.position.set(CONFIG.cameraPos.x, CONFIG.cameraPos.y, CONFIG.cameraPos.z);
+            camera.lookAt(0,0,0);
+        },
+        animate: function(elapsed) {
+            var tx = CONFIG.cameraPos.x + mouse.x * CONFIG.orbitStrength.x;
+            var ty = CONFIG.cameraPos.y - mouse.y * CONFIG.orbitStrength.y;
+            var tz = CONFIG.cameraPos.z - scrollOffset * CONFIG.scrollParallax;
+            camera.position.x = THREE.MathUtils.lerp(camera.position.x, tx, CONFIG.orbitDamping);
+            camera.position.y = THREE.MathUtils.lerp(camera.position.y, ty, CONFIG.orbitDamping);
+            camera.position.z = THREE.MathUtils.lerp(camera.position.z, tz, CONFIG.orbitDamping);
+            camera.lookAt(0,0,0);
+            if (Math.floor(elapsed*60) % 2 === 0) checkHover();
+            characterArms.forEach(function(ca) { ca.arm.rotation.z = ca.waving ? Math.sin(elapsed*8)*0.6 : THREE.MathUtils.lerp(ca.arm.rotation.z, 0, 0.1); });
+            for (var i = growingTrees.length-1; i >= 0; i--) { var gt = growingTrees[i]; gt.frame++; var p = Math.min(gt.frame/CONFIG.treeGrowFrames, 1); var e = 1-Math.pow(1-p,3); gt.obj.scale.set(e,e,e); if (p >= 1) growingTrees.splice(i,1); }
+        },
+        onMouseMove: function(x, y) { mouse.x = x; mouse.y = y; mouseVec.set(x, -y); },
+        onScroll: function(offset) { scrollOffset = offset; },
+        onClick: function(x, y) {
+            raycaster.setFromCamera(new THREE.Vector2(x, y), camera);
+            var hits = raycaster.intersectObject(solidGround);
+            if (hits.length > 0) {
+                var pt = hits[0].point; var tree = createTree(pt.x, pt.z, Math.random()>0.5?'cone':'round');
+                tree.scale.set(0,0,0); scene.add(tree); growingTrees.push({obj:tree,frame:0}); plantedTrees.push(tree);
+                if (plantedTrees.length > CONFIG.maxPlantedTrees) { scene.remove(plantedTrees.shift()); }
             }
-        }
-    }
-
-    function unhoverAll() {
-        if (currentHovered) {
-            currentHovered.traverse(function(child) {
-                if (child.userData.type === 'window') {
-                    child.material = windowMatOff;
-                }
-            });
-            characterArms.forEach(function(ca) { ca.waving = false; });
-            currentHovered = null;
-        }
-    }
-
-    // ========================================================================
-    // ANIMATION LOOP
-    // ========================================================================
-    var elapsed = 0;
-    function animate() {
-        animationId = requestAnimationFrame(animate);
-        elapsed += 0.016;
-
-        if (reducedMotion) {
-            renderer.render(scene, camera);
-            cancelAnimationFrame(animationId);
-            return;
-        }
-
-        // Camera orbit
-        var targetX = CONFIG.cameraPos.x + mouse.x * CONFIG.orbitStrength.x;
-        var targetY = CONFIG.cameraPos.y - mouse.y * CONFIG.orbitStrength.y;
-        var targetZ = CONFIG.cameraPos.z - scrollOffset * CONFIG.scrollParallax;
-        camera.position.x = THREE.MathUtils.lerp(camera.position.x, targetX, CONFIG.orbitDamping);
-        camera.position.y = THREE.MathUtils.lerp(camera.position.y, targetY, CONFIG.orbitDamping);
-        camera.position.z = THREE.MathUtils.lerp(camera.position.z, targetZ, CONFIG.orbitDamping);
-        camera.lookAt(0, 0, 0);
-
-        // Hover check (every other frame for perf)
-        if (Math.floor(elapsed * 60) % 2 === 0) {
-            checkHover();
-        }
-
-        // Character wave animation
-        characterArms.forEach(function(ca) {
-            if (ca.waving) {
-                ca.arm.rotation.z = Math.sin(elapsed * 8) * 0.6;
-            } else {
-                ca.arm.rotation.z = THREE.MathUtils.lerp(ca.arm.rotation.z, 0, 0.1);
-            }
-        });
-
-        // Growing trees
-        for (var i = growingTrees.length - 1; i >= 0; i--) {
-            var gt = growingTrees[i];
-            gt.frame++;
-            var progress = Math.min(gt.frame / CONFIG.treeGrowFrames, 1);
-            var eased = 1 - Math.pow(1 - progress, 3);
-            gt.obj.scale.set(eased, eased, eased);
-            if (progress >= 1) growingTrees.splice(i, 1);
-        }
-
-        renderer.render(scene, camera);
-    }
-
-    // ========================================================================
-    // TOGGLE BUTTON
-    // ========================================================================
-    function createToggle() {
-        var btn = document.createElement('button');
-        btn.className = 'village-toggle';
-        btn.setAttribute('aria-label', 'Toggle 3D village background');
-        btn.setAttribute('aria-pressed', 'true');
-        btn.textContent = '3D [ON]';
-        document.body.appendChild(btn);
-
-        btn.addEventListener('click', function() {
-            if (isRunning) {
-                stopScene();
-                btn.textContent = '3D [OFF]';
-                btn.setAttribute('aria-pressed', 'false');
-                localStorage.setItem('village-scene-enabled', 'false');
-            } else {
-                startScene();
-                btn.textContent = '3D [ON]';
-                btn.setAttribute('aria-pressed', 'true');
-                localStorage.setItem('village-scene-enabled', 'true');
-            }
-        });
-
-        return btn;
-    }
-
-    function startScene() {
-        if (canvas) canvas.style.display = 'block';
-        document.body.classList.add('village-active');
-        isRunning = true;
-        animate();
-    }
-
-    function stopScene() {
-        if (animationId) cancelAnimationFrame(animationId);
-        if (canvas) canvas.style.display = 'none';
-        document.body.classList.remove('village-active');
-        isRunning = false;
-    }
-
-    // ========================================================================
-    // RESIZE
-    // ========================================================================
-    var resizeTimer;
-    function onResize() {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(function() {
-            if (!renderer) return;
-            camera.aspect = window.innerWidth / window.innerHeight;
-            camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
-        }, 250);
-    }
-
-    // ========================================================================
-    // INIT
-    // ========================================================================
-    function init() {
-        var savedState = localStorage.getItem('village-scene-enabled');
-        if (savedState === 'false') {
-            var btn = createToggle();
-            btn.textContent = '3D [OFF]';
-            btn.setAttribute('aria-pressed', 'false');
-            return;
-        }
-
-        initScene();
-        initRenderer();
-        createToggle();
-
-        // Event listeners
-        window.addEventListener('mousemove', onMouseMove);
-        window.addEventListener('scroll', onScroll);
-        canvas.addEventListener('click', onClick);
-        window.addEventListener('resize', onResize);
-
-        // Theme changes
-        window.addEventListener('themechange', updateColors);
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateColors);
-
-        // Reduced motion
-        window.matchMedia('(prefers-reduced-motion: reduce)').addEventListener('change', function(e) {
-            reducedMotion = e.matches;
-            if (reducedMotion && isRunning) {
-                renderer.render(scene, camera);
-                cancelAnimationFrame(animationId);
-            } else if (!reducedMotion && isRunning) {
-                animate();
-            }
-        });
-
-        startScene();
-    }
-
-    // Wait for DOM
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
-    } else {
-        init();
-    }
+        },
+        resize: function(w, h) { if (camera) { camera.aspect = w/h; camera.updateProjectionMatrix(); } },
+        getScene: function() { return scene; },
+        getCamera: function() { return camera; },
+        updateColors: function(c) {
+            var ink = new THREE.Color(c.ink);
+            allMaterials.forEach(function(m) { if (m.color) m.color.set(ink); });
+            if (solidGround) solidGround.material.color.set(new THREE.Color(c.bg));
+        },
+        destroy: function() { scene = null; camera = null; plantedTrees = []; growingTrees = []; windowMeshes = []; characterArms = []; currentHovered = null; }
+    });
 })();


### PR DESCRIPTION
## Summary
- Full-page Three.js wireframe village scene behind all portfolio content
- Low-poly cottages, gardens, trees, characters, fences in black and white
- Interactive: mouse orbit, scroll parallax, click-to-plant trees, hover effects

## Type
- [x] Feature

## Changes
- `village-scene.js` — New file: scene, geometry, interactions, toggle (660 lines)
- `index.html` — Three.js CDN + village-scene.js script tags
- `css/components.css` — Canvas/toggle styles, body.village-active transparent bg, footer bg
- `css/base.css` — Print-hide rules for canvas + toggle

## Interactions
- Mouse move → camera orbit drift
- Scroll → parallax depth
- Click ground → plant tree (max 20, grow animation)
- Hover cottage → windows glow
- Hover character → waves
- Toggle button (3D ON/OFF) with localStorage

## Testing
- [ ] Scene renders behind content on staging.cjunker.dev
- [ ] Content cards remain opaque over canvas
- [ ] Mouse/scroll interactions work
- [ ] Click plants trees
- [ ] Hover effects on cottages and characters
- [ ] Toggle pauses/resumes, persists on reload
- [ ] Dark mode inverts colors
- [ ] Mobile: renders without layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)