### PR TITLE
fix: CI timeout + add paused state to scene toggle

### DIFF
--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -5,8 +5,8 @@
     "chromeLaunchConfig": {
       "args": ["--no-sandbox", "--disable-setuid-sandbox"]
     },
-    "timeout": 10000,
-    "wait": 1000
+    "timeout": 30000,
+    "wait": 3000
   },
   "urls": [
     {

--- a/particle-scene.js
+++ b/particle-scene.js
@@ -260,6 +260,7 @@
         getScene: function() { return scene; },
         getCamera: function() { return camera; },
         updateColors: function() { /* particles use their own palette */ },
+        pause: function() { /* shapeTime freezes via manager skipping animate() */ },
         destroy: function() { scene = null; camera = null; points = null; positions = null; targets = null; velocities = null; }
     });
 })();

--- a/scene-manager.js
+++ b/scene-manager.js
@@ -29,6 +29,7 @@
     var canvas, renderer;
     var animationId = null;
     var isRunning = false;
+    var isPaused = false;
     var elapsed = 0;
     var mouse = { x: 0, y: 0 };
     var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -73,7 +74,9 @@
             return;
         }
 
-        activeScene.animate(elapsed);
+        if (!isPaused) {
+            activeScene.animate(elapsed);
+        }
         renderer.render(activeScene.getScene(), activeScene.getCamera());
     }
 
@@ -149,7 +152,13 @@
         function updateAll() {
             Object.keys(buttons).forEach(function(name) {
                 var isActive = isRunning && activeSceneName === name;
-                buttons[name].textContent = name.toUpperCase() + (isActive ? ' [ON]' : '');
+                var label = name.toUpperCase();
+                if (isActive && isPaused) {
+                    label += ' [PAUSED]';
+                } else if (isActive) {
+                    label += ' [ON]';
+                }
+                buttons[name].textContent = label;
                 buttons[name].classList.toggle('active', isActive);
                 buttons[name].setAttribute('aria-pressed', isActive ? 'true' : 'false');
             });
@@ -186,11 +195,19 @@
 
         btn.addEventListener('click', function() {
             if (isRunning && activeSceneName === name) {
-                // Turn off
-                stopScene();
-                localStorage.setItem('scene-active', 'off');
+                if (!isPaused) {
+                    // ON → PAUSED
+                    isPaused = true;
+                    if (activeScene && activeScene.pause) activeScene.pause();
+                } else {
+                    // PAUSED → OFF
+                    isPaused = false;
+                    stopScene();
+                    localStorage.setItem('scene-active', 'off');
+                }
             } else {
-                // Switch to this scene
+                // Switch to this scene (or turn on from off)
+                isPaused = false;
                 switchScene(name);
                 startScene();
             }


### PR DESCRIPTION
## Summary
- Fix pa11y timeout causing CI failures (CDN scripts stalling)
- Add PAUSED state to scene toggle buttons (ON → PAUSED → OFF)

## Changes
- `.pa11yci.json` — timeout 30s (was 10s), wait 3s (was 1s)
- `scene-manager.js` — three-state cycle, isPaused flag, skip animate() when paused
- `particle-scene.js` — pause method stub

## Testing
- [ ] CI passes (pa11y no longer times out)
- [ ] Click PARTICLES: ON → click again: PAUSED (particles freeze) → click again: OFF
- [ ] Same behavior for VILLAGE
- [ ] Switching scenes from PAUSED resets to ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)