### PR TITLE
chore(ci): add Dependabot for npm, docker, and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  # Portfolio site npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Umami Dockerfile base images (node:20-alpine, postgres:16-alpine)
+  - package-ecosystem: "docker"
+    directory: "/umami"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+
+  # GitHub Actions versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Summary
- Weekly Monday Dependabot runs across three ecosystems: portfolio npm deps, Umami Dockerfile base images (`/umami`), and GitHub Actions versions
- PR limits per ecosystem (5/3/3) to keep the queue from flooding
- Conventional commit prefixes (`chore(deps)`, `chore(docker)`, `chore(ci)`) so semantic-release / changelogs stay clean

## Type
- [x] Feature (CI/automation)

## Test plan
- [ ] Merge → confirm Dependabot UI in repo settings picks up the config
- [ ] Wait for next Monday or trigger manually via Insights → Dependency graph → Dependabot
- [ ] Verify first PR uses correct commit prefix