### PR TITLE
chore(ci): add weekly canary build for staleness detection

### DIFF
--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -1,0 +1,95 @@
+name: Canary Build (Staleness Check)
+
+# Catches Docker build rot, dependency breakage, and security issues
+# before they surface during a real deploy.
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC — frequent enough to catch drift,
+    # infrequent enough to stay within free-tier Actions minutes.
+    - cron: "0 8 * * 1"
+  workflow_dispatch: # Manual trigger for testing the workflow itself
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  docker-build:
+    name: Umami Docker Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Umami image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./umami
+          file: ./umami/Dockerfile
+          push: false
+          tags: umami-canary:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - name: npm audit (portfolio)
+        run: npm audit --audit-level=high || true
+        # Non-blocking — just surfaces findings in the log.
+
+  open-issue-on-failure:
+    name: Alert on Failure
+    runs-on: ubuntu-latest
+    needs: [docker-build, dependency-audit]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create issue for build failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list \
+            --label "canary-failure" \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$existing" -gt 0 ]; then
+            echo "Open canary-failure issue already exists, skipping."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "Canary build failed — $(date -u +%Y-%m-%d)" \
+            --label "canary-failure" \
+            --body "$(cat <<'EOF'
+          ## Canary build failure
+
+          The weekly canary build failed. This means the next real deploy will also fail.
+
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ### Common causes
+          - Upstream dependency broke (Prisma engines, Next.js, etc.)
+          - Docker base image changed (Node Alpine)
+          - npm registry issue (transient — re-run to confirm)
+
+          ### Next steps
+          1. Check the failed job logs linked above
+          2. Fix the root cause on a branch
+          3. Close this issue when the fix merges
+          EOF
+          )"


### PR DESCRIPTION
## Summary
- Weekly Monday canary that builds the Umami Dockerfile (no push) and runs `npm audit` on the portfolio
- Auto-opens an issue labeled `canary-failure` on any job failure (de-duplicates if one is already open)
- Goal: catch Docker base image rot, broken transitive deps, and security findings *before* a real deploy needs to ship

## Type
- [x] Feature (CI/automation)

## Notes
- `dependency-audit` step is non-blocking (`|| true`) — surfaces findings in the log without auto-failing
- Manual `workflow_dispatch` available so we can verify it works without waiting until Monday

## Test plan
- [ ] Merge → trigger run via Actions UI (workflow_dispatch)
- [ ] Confirm both jobs pass on current `main`
- [ ] Force a failure (e.g., temporarily break Dockerfile on a test branch) → confirm issue is opened with `canary-failure` label