### PR TITLE
chore(infra): bump existing Node 20 pins to Node 24 LTS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/umami/Dockerfile
+++ b/umami/Dockerfile
@@ -3,7 +3,7 @@
 # Author: Chris Junker (optimized 2025-11-11)
 # Size: ~73 MB | Startup: ~1.4s | Security: A+ | Zero trust build
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 ARG UMAMI_VERSION=v2.13.2
 ARG TARGETARCH
 

--- a/umami/README.md
+++ b/umami/README.md
@@ -29,7 +29,7 @@ Self-hosted Umami analytics for cjunker.dev with zero-cost hosting and Cloudflar
 
 ## Docker Images
 
-- **Umami**: Optimized multi-stage build (Node 20 Alpine) - **~73MB** (down from 82MB, -11%)
+- **Umami**: Optimized multi-stage build (Node 24 Alpine) - **~73MB** (down from 82MB, -11%)
 - **PostgreSQL**: `postgres:16-alpine` (~240MB)
 - **Total stack size**: ~313MB (vs 1GB+ with standard images)
 


### PR DESCRIPTION
## Summary
- `.github/workflows/deploy.yml` → `node-version: '24'`
- `umami/Dockerfile` → `ARG NODE_VERSION=24`
- `umami/README.md` → docs reference updated

## Why
Node 20 enters maintenance in April 2026. Aligns existing pins with the active LTS so all three repos in the ecosystem (this PR, healthcheck #56, canary-build #55) target the same runtime.

## Type
- [x] Maintenance

## Test plan
- [ ] CI build (Test & Lint) passes on Node 24
- [ ] Umami Docker image builds locally on `node:24-alpine`
- [ ] Staging deploy succeeds before merging

## Related
- #54 dependabot
- #55 canary build (Node 24)
- #56 healthcheck (Node 24)