### PR TITLE
fix(ci): skip staging deploy on Dependabot PRs, run tests instead

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,12 @@ jobs:
   test:
     name: Test & Lint
     runs-on: ubuntu-latest
-    # ONLY run tests on push or manual — NEVER on PR (previews don't need tests)
+    # Run on push, manual dispatch, and Dependabot PRs (so dep bumps get test signal).
+    # Skipped on regular PRs — previews go straight to staging.
     if: |
       github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
     concurrency:
       group: test-${{ github.ref }}
       cancel-in-progress: true
@@ -78,11 +80,14 @@ jobs:
   deploy-staging:
     name: Deploy → Staging (staging.cjunker.dev)
     runs-on: ubuntu-latest
-    # NO `needs: test` → PRs deploy instantly without waiting
+    # NO `needs: test` → PRs deploy instantly without waiting.
+    # Skip Dependabot PRs — they don't have access to ACTIONS_DEPLOY_KEY
+    # (Dependabot secrets are scoped separately from regular repo secrets).
     if: |
-      github.ref != 'refs/heads/master' && github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging')
+      github.actor != 'dependabot[bot]' &&
+      (github.ref != 'refs/heads/master' && github.event_name == 'push' ||
+       github.event_name == 'pull_request' ||
+       (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging'))
     environment: staging
     concurrency:
       group: staging-deploy-${{ github.ref }}


### PR DESCRIPTION
## Summary
Dependabot PRs (#57–#63) are all failing the staging deploy with `"not found deploy key or tokens"`. Root cause: **Dependabot secrets are scoped separately from regular repo secrets** — `ACTIONS_DEPLOY_KEY` isn't visible to workflows triggered by `dependabot[bot]`.

## Changes to `deploy.yml`

1. **`deploy-staging`** — skip when triggered by `dependabot[bot]`. Dep bumps don't need a staging preview, and trying to deploy was failing red.
2. **`test` (Test & Lint)** — now runs on Dependabot PRs (previously skipped on all PRs). Gives us lint/test signal on dep bumps before merging.

## Net effect
- Dependabot PR shows ✅ green Test & Lint check
- `deploy-staging` cleanly **skipped** instead of failing red
- Regular human PRs unchanged: still skip Test & Lint, still deploy preview to staging

## Type
- [x] Bug fix (CI)

## Test plan
- [ ] Merge → Dependabot rebases its PRs against new master
- [ ] Verify any Dependabot PR shows: Test & Lint = ✅, Deploy → Staging = SKIPPED, Deploy → Production = SKIPPED
- [ ] Verify a non-Dependabot PR (push to a feature branch) still gets staging preview