### PR TITLE
fix(mobile): hamburger init state, scrolled header, scene toggle width

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -35,6 +35,16 @@ body {
     z-index: var(--z-sticky);
     padding: var(--space-md) var(--space-lg);
     margin-bottom: var(--space-xl);
+    transition: box-shadow var(--transition-fast), padding var(--transition-fast);
+}
+
+/* Scrolled state — stronger shadow and slight blur backdrop so the
+   header reads cleanly over decorative WebGL/pattern backgrounds. */
+.site-header.scrolled {
+    box-shadow: var(--shadow-md) var(--c-shadow);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    padding: var(--space-sm) var(--space-lg);
 }
 
 .site-header__content {
@@ -1357,6 +1367,10 @@ body.scene-focus .theme-switcher {
 }
 
 .village-toggle {
+    /* Reserve space for the longest possible label (e.g. "PARTICLES [PAUSED]")
+       so width doesn't jitter when the label changes between states. #65 */
+    min-width: 18ch;
+    text-align: left;
     background: var(--c-surface);
     border: var(--border-thick) solid var(--c-border);
     padding: var(--space-xs) var(--space-sm);

--- a/scripts.js
+++ b/scripts.js
@@ -18,6 +18,12 @@
         return;
     }
 
+    // Defensive: force closed state on every page load. Past regressions
+    // shipped HTML with aria-expanded="true", which made the first tap
+    // close the (visually-already-closed) menu. Issue #32.
+    menuToggle.setAttribute('aria-expanded', 'false');
+    document.body.style.overflow = '';
+
     /**
      * Toggle menu open/closed state
      */


### PR DESCRIPTION
## Summary
Three small mobile/nav bug fixes batched together.

## Changes

### #32 — Hamburger inverted state (`scripts.js`)
Defensive `aria-expanded="false"` enforcement on init. Past regressions shipped HTML with `aria-expanded="true"`, making the first tap close the (visually-already-closed) menu. JS now forces the correct state on every page load regardless of HTML drift.

### #6 — Scrolled header readability (`css/components.css`)
The \`.site-header.scrolled\` selector had **no CSS rule** — \`scripts.js\` was adding the class but nothing styled it. Added:
- Stronger box-shadow on scroll
- \`backdrop-filter: blur(6px)\` so the sticky header reads cleanly over the decorative WebGL/pattern backgrounds
- Tighter padding for a "shrink" effect

### #65 — Scene toggle button width (`css/components.css`)
`.village-toggle` now has `min-width: 18ch`, enough room for the longest possible label ("PARTICLES [PAUSED]"). Buttons no longer jitter horizontally when their labels change between OFF / [ON] / [PAUSED] states.

## Type
- [x] Bug fix (mobile)
- [x] Bug fix (visual polish)

## Test plan
- [ ] Mobile viewport (DevTools <768px): page loads with menu closed; first tap opens, second closes
- [ ] Scroll down: header background looks more solid, slight blur visible
- [ ] Click VILLAGE/PARTICLES toggles: button width does not change between states
- [ ] Desktop layout unaffected

## Closes
- #32
- #6
- #65