### PR TITLE
feat(mobile): WCAG 2.5.5 touch targets + iPhone safe-area-insets

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -14,7 +14,12 @@
 body {
     background-color: var(--c-bg);
     color: var(--c-ink);
-    padding: var(--space-xl);
+    /* Honor iPhone X+ safe-area-insets in landscape (notch / rounded corners).
+       The max() pattern keeps existing padding on devices without insets. */
+    padding-top: var(--space-xl);
+    padding-right: max(var(--space-xl), env(safe-area-inset-right));
+    padding-bottom: max(var(--space-xl), env(safe-area-inset-bottom));
+    padding-left: max(var(--space-xl), env(safe-area-inset-left));
     margin: 0;
 }
 
@@ -198,7 +203,12 @@ body {
    3. BUTTONS
    ========================================================================== */
 .btn {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* WCAG 2.5.5 — minimum 44x44 touch target. Use 48 for comfortable taps. */
+    min-height: 48px;
+    min-width: 48px;
     padding: var(--space-sm) var(--space-lg);
     font-family: var(--font-mono);
     font-weight: 700;
@@ -376,7 +386,11 @@ body {
 
 /* Action Button inside card - Hard shadow style */
 .brutal-card-v2__action {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* WCAG 2.5.5 — minimum 44x44 touch target. */
+    min-height: 48px;
     background-color: var(--c-surface);
     color: var(--c-ink);
     border: var(--border-thick) solid var(--c-border);
@@ -555,6 +569,10 @@ body {
 }
 
 .project-card__link {
+    display: inline-flex;
+    align-items: center;
+    /* WCAG 2.5.5 — minimum 44x44 touch target. */
+    min-height: 44px;
     color: var(--c-accent);
     font-weight: 600;
     padding: var(--space-xs) var(--space-sm);
@@ -832,6 +850,12 @@ body {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+    /* WCAG 2.5.5 — minimum 44x44 touch target. */
+    min-width: 44px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: var(--c-ink);
     color: var(--c-surface);
     border: var(--border-thick) solid var(--c-border);

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="description" content="Christopher Junker - Senior Software Engineer specializing in distributed systems, observability, and cloud-native technologies">
     <meta name="author" content="Christopher Junker">
     <meta name="keywords" content="software engineer, Go, Ruby on Rails, Kubernetes, AWS, distributed systems, observability, Datadog">


### PR DESCRIPTION
## Summary
Two enhancements for mobile / touch users.

### #14 — WCAG 2.5.5 touch targets
Minimum 44x44 CSS pixels on all primary interactive elements:

| Selector | Min size | Why |
|---|---|---|
| `.btn` | 48×48 | Primary CTAs (Email, GitHub, LinkedIn, Resume) |
| `.brutal-card-v2__action` | 48 high | Project card action buttons |
| `.project-card__link` | 44 high | "View on GitHub" links |
| `.carousel-btn` | 44×44 | Carousel prev/next |
| `.nav-link` | 48 high | (already had this) |

### #16 — Safe-area-insets for iPhone X+
- `<meta viewport>` now includes `viewport-fit=cover`
- `body` padding uses `max(var(--space-xl), env(safe-area-inset-*))` so devices with notches/rounded corners get extra padding in landscape, but devices without insets keep the existing layout untouched.

## Type
- [x] Feature (a11y)
- [x] Feature (mobile)

## Test plan
- [ ] Mobile DevTools: tap targets all clickable area ≥44px
- [ ] iPhone simulator landscape: content not clipped by notch
- [ ] Desktop: no visible layout change

## Closes
- #14
- #16