### PR TITLE
feat(mobile): gate transform hovers behind (hover: hover) [closes #15]

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -888,10 +888,14 @@ body {
     transition: box-shadow var(--transition-fast), transform var(--transition-fast);
 }
 
-.about-section:hover,
-.contact-section:hover {
-    box-shadow: 4px 4px 0 var(--c-shadow);
-    transform: translate(-1px, -1px);
+/* Hover transforms only on devices with reliable hover (skip touch
+   to avoid sticky hover-state after tap-then-tap-elsewhere). #15.3 */
+@media (hover: hover) and (pointer: fine) {
+    .about-section:hover,
+    .contact-section:hover {
+        box-shadow: 4px 4px 0 var(--c-shadow);
+        transform: translate(-1px, -1px);
+    }
 }
 
 .about-section__paragraph,


### PR DESCRIPTION
## Summary
Closes the bulk of #15 by adding the one remaining piece — most of the issue's recommendations were already implemented during earlier work.

## Already done elsewhere

| Task | Status | Where |
|---|---|---|
| 2.1 Grid overflow on 320px | ✅ done | \`.projects-grid\` already uses \`minmax(min(300px, 100%), 1fr)\` |
| 2.2 prefers-reduced-motion | ✅ done | Global rule in \`css/base.css:258\` |
| 2.2 Preconnect to CDN | ❎ moot | Three.js + D3 vendored (PR #70); Mermaid lazy-loaded on modal open |

## What's in this PR

**2.3 Avoid sticky hover on touch devices**
Wrap the `.about-section` / `.contact-section` transform hover in `@media (hover: hover) and (pointer: fine)` so touch users don't get a stuck visual state after tap-then-tap-elsewhere.

## Type
- [x] Feature (mobile UX)

## Test plan
- [ ] Mobile (no hover): tapping the About card no longer leaves it in transformed state
- [ ] Desktop: hover still triggers the small translate

## Closes
- #15