### PR TITLE
feat(content): add Agentic Portfolio + Hush-Hush to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,6 +296,56 @@
 
                 <article class="brutal-card-v2 brutal-card-v2--halftone">
                     <div class="brutal-card-v2__header">
+                        <h3 class="brutal-card-v2__title">AGENTIC_PORTFOLIO</h3>
+                    </div>
+                    <div class="brutal-card-v2__content">
+                        <p class="project-card__tech">
+                            <small>Python • Pydantic • LangGraph • Railway • pytest</small>
+                        </p>
+                        <p>
+                            Paper-trading runner that parses LLM-generated 5-tier ratings from a sibling
+                            TradingAgents graph and executes against a pluggable broker abstraction.
+                            86 tests at 80%+ coverage, mypy strict, atomic JSONL audit trails for orders/decisions/equity,
+                            and deterministic idempotency keys for safe re-runs. Paper-to-live swap by config change.
+                        </p>
+                        <div class="project-card__actions">
+                            <a href="https://github.com/cjunks94/agentic-portfolio"
+                               class="project-card__link"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                View on GitHub &rarr;
+                            </a>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="brutal-card-v2 brutal-card-v2--halftone">
+                    <div class="brutal-card-v2__header">
+                        <h3 class="brutal-card-v2__title">HUSH_HUSH</h3>
+                    </div>
+                    <div class="brutal-card-v2__content">
+                        <p class="project-card__tech">
+                            <small>Go • SQLite • AES-256-GCM • Railway</small>
+                        </p>
+                        <p>
+                            Self-hosted secrets API with AES-256-GCM at rest, AAD-bound encryption preventing
+                            tampering and algorithm-downgrade attacks, and constant-time SHA-256 token comparison
+                            (timing-side-channel resistant). Single-binary Go deployment, structured slog logging
+                            with request-id correlation, idempotent CRUD on SQLite WAL.
+                        </p>
+                        <div class="project-card__actions">
+                            <a href="https://github.com/cjunks94/hush-hush"
+                               class="project-card__link"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                View on GitHub &rarr;
+                            </a>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="brutal-card-v2 brutal-card-v2--halftone">
+                    <div class="brutal-card-v2__header">
                         <h3 class="brutal-card-v2__title">EXPORTEE</h3>
                     </div>
                     <div class="brutal-card-v2__content">

--- a/tech-radar.csv
+++ b/tech-radar.csv
@@ -6,6 +6,8 @@ TypeScript,adopt,languages-frameworks,FALSE,"Panoptrain real-time NYC subway tra
 React,adopt,languages-frameworks,FALSE,"Production frontend at 2U; React 19 in Panoptrain client with MapLibre GL integration"
 Hono,trial,languages-frameworks,TRUE,"Modern lightweight web framework powering Panoptrain server (TypeScript, edge-ready, minimal overhead)"
 Astro,trial,languages-frameworks,TRUE,"Static blog at blog.cjunker.dev — Astro 6 + MDX, Dockerfile build, Railway deployment"
+LangGraph,trial,languages-frameworks,TRUE,"Agentic LLM workflows — sibling TradingAgents graph in Agentic Portfolio produces 5-tier ratings parsed into trade decisions"
+Pydantic,trial,languages-frameworks,TRUE,"Runtime validation + structured config in Agentic Portfolio; type-safe agent input/output schemas"
 AWS,adopt,platforms,FALSE,"Daily: EC2, Lambda, S3, RDS, IAM, Secrets Manager, SQS/SNS, CloudWatch, DocumentDB"
 Kubernetes,adopt,platforms,FALSE,"Self-managed K8s on EC2 at 2U; Helm charts, HPA, rolling updates, liveness/readiness probes"
 Docker,adopt,platforms,FALSE,"Daily containerization across services; multi-stage builds (Umami image: 73MB Alpine, ~1.4s startup)"


### PR DESCRIPTION
## Summary
Adds two new featured project cards plus matching tech radar entries. Together they fill two gaps in the portfolio: **AI engineering** (agentic workflows, LLM output parsing) and **security depth** (applied cryptography, side-channel-resistant auth).

## Project cards (`index.html`)

### AGENTIC_PORTFOLIO
**Python • Pydantic • LangGraph • Railway • pytest**

Paper-trading runner that parses LLM-generated 5-tier ratings from a sibling TradingAgents graph and executes against a pluggable broker abstraction. 86 tests at 80%+ coverage, mypy strict, atomic JSONL audit trails for orders/decisions/equity, deterministic idempotency keys for safe re-runs. Paper-to-live swap by config change.

### HUSH_HUSH
**Go • SQLite • AES-256-GCM • Railway**

Self-hosted secrets API with AES-256-GCM at rest, AAD-bound encryption preventing tampering and algorithm-downgrade attacks, and constant-time SHA-256 token comparison (timing-side-channel resistant). Single-binary Go deployment, structured slog logging with request-id correlation, idempotent CRUD on SQLite WAL.

## Tech radar additions (`tech-radar.csv`)
| Tech | Ring | Quadrant | New |
|---|---|---|---|
| LangGraph | Trial | Languages & Frameworks | ✓ |
| Pydantic | Trial | Languages & Frameworks | ✓ |

## Type
- [x] Feature (content)

## Verification
- `npm run lint` — clean
- `npm test` — pass
- `npm run test:a11y` — 0 errors

## Test plan
- [ ] Staging preview shows two new project cards in the FEATURED PROJECTS grid
- [ ] Both GitHub links resolve (`cjunks94/agentic-portfolio`, `cjunks94/hush-hush`)
- [ ] Tech radar shows LangGraph + Pydantic blips with ▲ new markers
- [ ] No layout regression in the projects grid at mobile width