### PR TITLE
fix(ci): restore staging custom domain via Pages API after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,22 +108,26 @@ jobs:
           publish_branch: gh-pages
           publish_dir: .
           cname: staging.cjunker.dev
-          # Drop force_orphan + keep existing files so the CNAME file
-          # and Pages config persist across deploys. force_orphan was
-          # making GitHub treat each push as a fresh setup, dropping
-          # the custom domain back to null.
-          force_orphan: false
-          keep_files: true
+          force_orphan: true
+          keep_files: false
           exclude_assets: '.github,node_modules,tests,package*.json,.gitignore,.stylelintrc.json,.htmlvalidate.json,decisions,TODO.md,CLAUDE.md,analytics-config.js,umami,healthcheck'
-      - name: Verify CNAME landed
+      - name: Restore Pages config custom domain
+        # GitHub Pages drops the custom domain on the staging repo's Pages
+        # config (cname: null) after every force_orphan deploy, even though
+        # the CNAME file is correct. This forces it back via the API.
+        # Requires STAGING_PAGES_PAT (fine-grained PAT, Pages: Read+Write
+        # scoped to cjunks94/resume-improvements-staging).
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.STAGING_PAGES_PAT }}
         run: |
           sleep 10
-          echo "## Pages config after deploy" >> $GITHUB_STEP_SUMMARY
+          gh api -X PUT repos/cjunks94/resume-improvements-staging/pages \
+            -f cname=staging.cjunker.dev \
+            -F https_enforced=true
+          echo "## Pages config after restore" >> $GITHUB_STEP_SUMMARY
           gh api repos/cjunks94/resume-improvements-staging/pages \
-            --jq '{cname, status, html_url}' \
-            >> $GITHUB_STEP_SUMMARY || echo "(read access on staging repo not available — check manually)"
+            --jq '{cname, status, html_url, https_enforced}' \
+            >> $GITHUB_STEP_SUMMARY
       - name: Summary
         run: |
           cat <<EOF >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,14 +108,22 @@ jobs:
           publish_branch: gh-pages
           publish_dir: .
           cname: staging.cjunker.dev
-          force_orphan: true
-          keep_files: false
+          # Drop force_orphan + keep existing files so the CNAME file
+          # and Pages config persist across deploys. force_orphan was
+          # making GitHub treat each push as a fresh setup, dropping
+          # the custom domain back to null.
+          force_orphan: false
+          keep_files: true
           exclude_assets: '.github,node_modules,tests,package*.json,.gitignore,.stylelintrc.json,.htmlvalidate.json,decisions,TODO.md,CLAUDE.md,analytics-config.js,umami,healthcheck'
-      - name: Wait for deployment and verify CNAME
+      - name: Verify CNAME landed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Waiting for GitHub Pages deployment to complete..."
           sleep 10
-          echo "✅ Deployment complete - CNAME should be preserved by action"
+          echo "## Pages config after deploy" >> $GITHUB_STEP_SUMMARY
+          gh api repos/cjunks94/resume-improvements-staging/pages \
+            --jq '{cname, status, html_url}' \
+            >> $GITHUB_STEP_SUMMARY || echo "(read access on staging repo not available — check manually)"
       - name: Summary
         run: |
           cat <<EOF >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
The earlier \`keep_files: true\` approach didn't fix the Pages config drift — staging.cjunker.dev still resets to \`cname: null\` after each deploy. Switching to plan A: post-deploy Pages API PUT.

## Diagnosis confirmed
\`\`\`
$ gh api repos/cjunks94/resume-improvements-staging/pages
{ "cname": null, "status": "built" }
\`\`\`
Even after the previous fix tried, the Pages config layer drops the custom domain. The CNAME *file* in gh-pages is correct, but GitHub's Pages settings ignore it after force_orphan deploys.

## Fix
Restored the original deploy config (\`force_orphan: true\`, \`keep_files: false\` — clean deploys) and added a post-deploy step that PUTs the cname via the Pages API:

\`\`\`yaml
- name: Restore Pages config custom domain
  env:
    GH_TOKEN: \${{ secrets.STAGING_PAGES_PAT }}
  run: |
    sleep 10
    gh api -X PUT repos/cjunks94/resume-improvements-staging/pages \
      -f cname=staging.cjunker.dev \
      -F https_enforced=true
\`\`\`

Plus a summary print so future drift is visible in the run log.

## ⚠️ Required user action before merge

1. Create a **fine-grained PAT** at https://github.com/settings/personal-access-tokens/new
   - Token name: \`staging-pages-cname\` (or similar)
   - Resource owner: \`cjunks94\`
   - Repository access: **Only select repositories** → \`cjunks94/resume-improvements-staging\`
   - Permissions: **Pages → Read and write**
   - Expiration: 90+ days
2. Copy the token, then add it as a repo secret here:
   - Settings → Secrets and variables → Actions → **New repository secret**
   - Name: \`STAGING_PAGES_PAT\`
   - Value: (paste token)
3. Then merge

If the secret is missing, the workflow will fail loudly on the new step (rather than silently swallow it), making it obvious what's needed.

## Type
- [x] Bug fix (CI/infra)

## Test plan
- [ ] After merge, master push triggers staging redeploy
- [ ] Job summary shows \`{ "cname": "staging.cjunker.dev", ... }\`
- [ ] \`https://staging.cjunker.dev\` loads the site (not the GH default URL)
- [ ] Subsequent deploys preserve the cname