### PR TITLE
fix(mobile): declutter — hide theme switcher + scene toggles, tighten body padding

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1443,10 +1443,22 @@ body.scene-focus .theme-switcher {
 
 /* Mobile: hide the FOCUS / VILLAGE / PARTICLES toggles — the decorative
    3D scene toggle is a desktop-only flourish; on mobile it just steals
-   real estate from content. */
+   real estate from content.
+
+   Safeguard: if body.scene-focus carried over from a desktop session
+   (or a resize event), the only exit control is .scene-toggles which
+   we just hid. Re-show core content unconditionally on mobile so the
+   user can never get locked out of an invisible-content state. */
 @media (max-width: 768px) {
     .scene-toggles {
         display: none;
+    }
+
+    body.scene-focus .site-header,
+    body.scene-focus .site-main,
+    body.scene-focus .site-footer {
+        opacity: 1;
+        pointer-events: auto;
     }
 }
 

--- a/css/components.css
+++ b/css/components.css
@@ -23,6 +23,15 @@ body {
     margin: 0;
 }
 
+/* Mobile: tighten horizontal padding so cards fill the viewport.
+   32px each side was eating ~17% of an iPhone 13 mini width. */
+@media (max-width: 768px) {
+    body {
+        padding-right: max(var(--space-md), env(safe-area-inset-right));
+        padding-left: max(var(--space-md), env(safe-area-inset-left));
+    }
+}
+
 /* Main content area */
 .site-main {
     padding-top: var(--space-xl);
@@ -1299,12 +1308,12 @@ body {
     box-shadow: var(--shadow-sm) var(--c-shadow);
 }
 
-/* Mobile: Move theme switcher below header to avoid overlap */
+/* Mobile: hide theme switcher entirely — declutters narrow viewports.
+   Desktop users still get all three themes; mobile defaults to whichever
+   theme is saved (or the system default). */
 @media (max-width: 768px) {
     .theme-switcher {
-        top: auto;
-        bottom: var(--space-lg);
-        right: var(--space-md);
+        display: none;
     }
 }
 
@@ -1432,10 +1441,12 @@ body.scene-focus .theme-switcher {
     background: var(--c-bg);
 }
 
+/* Mobile: hide the FOCUS / VILLAGE / PARTICLES toggles — the decorative
+   3D scene toggle is a desktop-only flourish; on mobile it just steals
+   real estate from content. */
 @media (max-width: 768px) {
-    .village-toggle {
-        bottom: var(--space-lg);
-        left: var(--space-md);
+    .scene-toggles {
+        display: none;
     }
 }
 


### PR DESCRIPTION
## Summary
User feedback: mobile is too cluttered, cards feel too narrow. Three small mobile fixes addressing all three.

## Changes (all gated behind `@media (max-width: 768px)`)

### 1. Hide theme switcher
The 3-color palette swap UI is a desktop-only flourish. Mobile keeps whatever theme is saved (or the system default).

### 2. Hide scene toggles (FOCUS / VILLAGE / PARTICLES)
The 3D background scene toggle stole bottom-left real estate on small viewports. WebGL on mobile is also a bad combination — the scene-manager already bails in headless and on slow devices, this just hides the controls UI to match.

### 3. Body horizontal padding `--space-xl` (32px) → `--space-md` (16px)
32px each side was eating ~17% of an iPhone 13 mini's 375px width. Cards now actually fill the viewport. The `max(..., env(safe-area-inset-*))` pattern is preserved so notched devices still get insets.

## Type
- [x] Bug fix (mobile UX)

## Verified locally
- `npm run lint` clean
- `npm test` pass
- `npm run test:a11y` 0 errors

## Test plan
- [ ] DevTools at iPhone 13 mini (375px): theme switcher gone, scene toggles gone, cards span ~94% of viewport
- [ ] DevTools at iPad/tablet (≥769px): everything as before
- [ ] Desktop: zero visible change

## What's NOT included (separate concerns)
- Could also reduce `.brutal-card-v2` outer padding on mobile if you want even more card width — defer until you see this PR's effect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved mobile viewport fit with reduced horizontal padding while preserving safe-area insets
  * Streamlined mobile UI by hiding the theme switcher on small screens
  * Simplified 3D scene controls on mobile: removed special positioning for the village toggle, hidden scene toggles, and restored the main layout to visible/interactive when a scene remains focused after switching or resizing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->