### PR TITLE
fix(mobile): restore three hamburger bars (combined selector bug)

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -96,19 +96,15 @@ body {
     transform: translate(2px, 2px);
 }
 
-/* Hamburger icon */
+/* Hamburger icon — 14px tall container with three 2px bars.
+   Top and bottom bars are pseudo-elements; middle bar is a centered
+   2px-tall linear-gradient on the container itself. */
 .nav-toggle__icon {
     display: block;
     position: relative;
     width: 20px;
     height: 14px;
-}
-
-.nav-toggle__icon,
-.nav-toggle__icon::before,
-.nav-toggle__icon::after {
-    background: currentColor;
-    height: 2px;
+    background: linear-gradient(currentColor, currentColor) center/100% 2px no-repeat;
     transition: all var(--transition-normal);
 }
 
@@ -118,6 +114,9 @@ body {
     position: absolute;
     left: 0;
     width: 100%;
+    height: 2px;
+    background: currentColor;
+    transition: all var(--transition-normal);
 }
 
 .nav-toggle__icon::before { top: 0; }


### PR DESCRIPTION
## Summary
The mobile hamburger icon renders as a single stretched bar instead of three. Found while reviewing mobile DevTools.

## Root cause
A combined CSS selector overrides the container's height:
\`\`\`css
.nav-toggle__icon { height: 14px; }     /* container */

.nav-toggle__icon,                       /* ← container included by mistake */
.nav-toggle__icon::before,
.nav-toggle__icon::after {
    height: 2px;                         /* ← clobbers the 14px above */
}
\`\`\`
With a 2px-tall container, \`::before\` at \`top: 0\` and \`::after\` at \`bottom: 0\` are at the same vertical position. All three bars visually overlap.

## Fix
- Container keeps \`height: 14px\` for spacing
- Middle bar is now a centered \`linear-gradient(currentColor, currentColor) center/100% 2px no-repeat\` on the container itself
- \`::before\` and \`::after\` get their own explicit \`height: 2px\` separately

The X-transform on \`aria-expanded="true"\` still works — overrides container background to transparent + rotates the pseudo-elements.

## Type
- [x] Bug fix (mobile UX)

## Verified
- \`npm run lint\` clean
- \`npm test\` pass
- \`npm run test:a11y\` 0 errors

## Test plan
- [ ] DevTools mobile (<768px): hamburger shows 3 distinct horizontal bars
- [ ] Tap to open: bars rotate into X
- [ ] Tap to close: X rotates back to bars
- [ ] Desktop: nav-toggle still hidden (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved internal styling for the mobile navigation toggle component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->