### PR TITLE
fix(content): resolve agentic mermaid syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -937,7 +937,7 @@ graph TB
     end
 
     subgraph "Strategy"
-        Advisor["🧠 Advisor<br/>(parses **Rating**: line)"]
+        Advisor["🧠 Advisor<br/>(parses Rating: line)"]
         Strategy["📐 Strategy<br/>(target weights per rating)"]
         Runner["🏃 Runner<br/>(propose deltas, threshold trivials)"]
     end
@@ -956,7 +956,7 @@ graph TB
     end
 
     subgraph "Idempotency Key"
-        Key["{trade_date}:{ticker}:<br/>{side}:{shares_rounded}"]
+        Key["(trade_date):(ticker):<br/>(side):(shares_rounded)"]
     end
 
     Cron --> Runner


### PR DESCRIPTION
## Summary
- Agentic Portfolio architecture modal was failing to render with a Mermaid syntax error.
- Two label patterns were tripping Mermaid 10's parser: bare `**bold**` (only valid in backtick-fenced markdown labels) and curly-brace placeholders (`{` opens a rhombus shape, and `{...}:` sequences confuse the lexer even inside quoted strings).

## Type
- [x] Bug fix

## Changes
- Strip `**` from Advisor node label: `(parses **Rating**: line)` → `(parses Rating: line)`
- Swap `{...}` placeholders for `(...)` in the Idempotency Key node

## Test plan
- [ ] Open Agentic Portfolio architecture modal — verify diagram renders without console error
- [ ] Confirm Exportee-Rails modal still renders (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined labels and formatting in the architecture diagram to enhance consistency and improve readability across the notation and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->