### PR TITLE
fix(content): rename Strategy node to break agentic mermaid cycle

### DIFF
--- a/index.html
+++ b/index.html
@@ -938,7 +938,7 @@ graph TB
 
     subgraph "Strategy"
         Advisor["🧠 Advisor<br/>(parses Rating: line)"]
-        Strategy["📐 Strategy<br/>(target weights per rating)"]
+        Strat["📐 Strategy<br/>(target weights per rating)"]
         Runner["🏃 Runner<br/>(propose deltas, threshold trivials)"]
     end
 
@@ -964,8 +964,8 @@ graph TB
     Runner --> TA
     TA --> Out
     Out --> Advisor
-    Advisor --> Strategy
-    Strategy --> Runner
+    Advisor --> Strat
+    Strat --> Runner
     Runner --> Iface
     Iface --> Paper
     Iface -.-> Live


### PR DESCRIPTION
## Summary
- Agentic Portfolio architecture modal failed to render with `Setting Strategy as parent of Strategy would create a cycle`.
- Cause: a node `Strategy[...]` lived inside a subgraph also titled `"Strategy"`. Mermaid resolves both to the same id, then refuses to render because the node would be its own subgraph parent.

## Type
- [x] Bug fix

## Changes
- Rename the node id `Strategy` → `Strat` inside `subgraph "Strategy"` (displayed label "📐 Strategy" unchanged)
- Update the two edges that referenced it: `Advisor --> Strat`, `Strat --> Runner`

## Test plan
- [ ] Open Agentic Portfolio architecture modal — diagram renders, no console error
- [ ] Confirm Exportee-Rails modal still renders (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagram labels in the Agentic Portfolio Architecture visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->