### PR TITLE
fix(ui): make particle scene background and palette theme-aware

### DIFF
--- a/particle-scene.js
+++ b/particle-scene.js
@@ -23,8 +23,9 @@
     var scrollOffset = 0;
     var shapeTime = 0;
 
-    // Color palette — muted but varied
-    var PALETTE = [
+    // Color palettes — picked per active theme bg so particles stay visible on
+    // both light and dark surfaces. Selection is driven by --c-bg luminance.
+    var DARK_PALETTE = [
         new THREE.Color('#3D6649'),  // forest green (accent)
         new THREE.Color('#5B9BD5'),  // soft blue
         new THREE.Color('#D9534F'),  // muted red
@@ -33,6 +34,36 @@
         new THREE.Color('#4A7A58'),  // light green
         new THREE.Color('#C0956C'),  // tan
     ];
+    var LIGHT_PALETTE = [
+        new THREE.Color('#1B4332'),  // deep forest
+        new THREE.Color('#1E40AF'),  // royal blue
+        new THREE.Color('#991B1B'),  // brick red
+        new THREE.Color('#B45309'),  // burnt amber
+        new THREE.Color('#5B21B6'),  // deep purple
+        new THREE.Color('#15803D'),  // emerald
+        new THREE.Color('#78350F'),  // dark brown
+    ];
+
+    function getThemeBg() {
+        var v = getComputedStyle(document.documentElement).getPropertyValue('--c-bg').trim();
+        return v || '#0d1117';
+    }
+
+    function isLightBg(hex) {
+        var c = hex.replace('#', '');
+        if (c.length === 3) c = c[0]+c[0]+c[1]+c[1]+c[2]+c[2];
+        if (c.length !== 6) return false;
+        var r = parseInt(c.slice(0, 2), 16);
+        var g = parseInt(c.slice(2, 4), 16);
+        var b = parseInt(c.slice(4, 6), 16);
+        // Perceived brightness (Rec.601). >140 ≈ light enough that the dark
+        // palette would wash out.
+        return (0.299 * r + 0.587 * g + 0.114 * b) > 140;
+    }
+
+    function activePalette() {
+        return isLightBg(getThemeBg()) ? LIGHT_PALETTE : DARK_PALETTE;
+    }
 
     // ========================================================================
     // SHAPE GENERATORS
@@ -132,7 +163,7 @@
     window.SceneManager.register('particles', {
         init: function(renderer, canvas) {
             scene = new THREE.Scene();
-            scene.background = new THREE.Color('#0d1117');
+            scene.background = new THREE.Color(getThemeBg());
             camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 100);
             camera.position.set(0, 0, 14);
             camera.lookAt(0, 0, 0);
@@ -145,6 +176,7 @@
             var colorsArr = new Float32Array(PARTICLE_COUNT * 3);
 
             var firstShape = shapeData[0];
+            var palette = activePalette();
             for (var i = 0; i < PARTICLE_COUNT; i++) {
                 var i3 = i * 3;
                 positions[i3] = firstShape[i].x;
@@ -154,8 +186,8 @@
                 targets[i3 + 1] = firstShape[i].y;
                 targets[i3 + 2] = firstShape[i].z;
 
-                // Assign color from palette
-                var col = PALETTE[Math.floor(Math.random() * PALETTE.length)];
+                // Assign color from active-theme palette
+                var col = palette[Math.floor(Math.random() * palette.length)];
                 colorsArr[i3] = col.r;
                 colorsArr[i3 + 1] = col.g;
                 colorsArr[i3 + 2] = col.b;
@@ -259,7 +291,19 @@
         resize: function(w, h) { if (camera) { camera.aspect = w / h; camera.updateProjectionMatrix(); } },
         getScene: function() { return scene; },
         getCamera: function() { return camera; },
-        updateColors: function() { /* particles use their own palette */ },
+        updateColors: function() {
+            if (!scene || !points || !particleColors) return;
+            scene.background = new THREE.Color(getThemeBg());
+            var palette = activePalette();
+            for (var i = 0; i < PARTICLE_COUNT; i++) {
+                var i3 = i * 3;
+                var col = palette[Math.floor(Math.random() * palette.length)];
+                particleColors[i3]     = col.r;
+                particleColors[i3 + 1] = col.g;
+                particleColors[i3 + 2] = col.b;
+            }
+            points.geometry.attributes.color.needsUpdate = true;
+        },
         pause: function() { /* shapeTime freezes via manager skipping animate() */ },
         animatePaused: function(elapsed) {
             // Mouse split + velocity only — no shape morphing

--- a/particle-scene.js
+++ b/particle-scene.js
@@ -50,12 +50,23 @@
     }
 
     function isLightBg(hex) {
-        var c = hex.replace('#', '');
-        if (c.length === 3) c = c[0]+c[0]+c[1]+c[1]+c[2]+c[2];
-        if (c.length !== 6) return false;
-        var r = parseInt(c.slice(0, 2), 16);
-        var g = parseInt(c.slice(2, 4), 16);
-        var b = parseInt(c.slice(4, 6), 16);
+        var c = (hex || '').trim();
+        var r, g, b;
+        if (c.charAt(0) === '#') {
+            c = c.slice(1);
+            if (c.length === 3) c = c[0]+c[0]+c[1]+c[1]+c[2]+c[2];
+            if (c.length !== 6) return false;
+            r = parseInt(c.slice(0, 2), 16);
+            g = parseInt(c.slice(2, 4), 16);
+            b = parseInt(c.slice(4, 6), 16);
+        } else {
+            // Browsers can resolve a custom property to rgb()/rgba() — accept
+            // either form so light-theme detection still works.
+            var m = c.match(/^rgba?\(\s*([0-9.]+)[,\s]+([0-9.]+)[,\s]+([0-9.]+)/i);
+            if (!m) return false;
+            r = parseFloat(m[1]); g = parseFloat(m[2]); b = parseFloat(m[3]);
+        }
+        if (isNaN(r) || isNaN(g) || isNaN(b)) return false;
         // Perceived brightness (Rec.601). >140 ≈ light enough that the dark
         // palette would wash out.
         return (0.299 * r + 0.587 * g + 0.114 * b) > 140;


### PR DESCRIPTION
## Summary
- Particle scene's `scene.background` was hardcoded to `#0d1117`, so light-theme cards sat on a dark navy backdrop while the rest of the page rendered with light surfaces (visible jank in the screenshot context where this was reported).
- Now reads `--c-bg` from CSS vars and picks one of two hand-tuned palettes based on perceived brightness of the resolved bg, so particles stay legible on both light and dark surfaces.
- `updateColors` is no longer a stub — re-paints bg and re-bakes the particle color buffer when SceneManager fires its `themechange` / `prefers-color-scheme` hooks, so flipping themes live-updates without a reload.

## Test plan
- [ ] Load with default (blueprint) theme in light mode → particles sit on `#E8EAF6` with the darker palette (deep forest, royal blue, brick red, burnt amber, deep purple, emerald, dark brown)
- [ ] Switch to forest theme → particles render on `#f4f1de` cream; switch to industrial → `#FFF8E1` manila
- [ ] Toggle OS dark mode → particles repaint with the original `DARK_PALETTE` on `#0d1117` / `#1a1a18` / `#1a1815`
- [ ] Toggle theme dots while particles are active → bg + colors live-update (no reload required)
- [ ] Confirm village scene still renders correctly (no changes to it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Particle scene now adapts to the current theme: background and particle colors switch between light/dark palettes based on theme luminance and update dynamically when the theme changes, providing a more cohesive visual experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cjunks94/resume-improvements/pull/87)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->